### PR TITLE
Link fixed

### DIFF
--- a/en/developer/desktop-sdk/using-the-desktop-sdk/loading-dashboards.md
+++ b/en/developer/desktop-sdk/using-the-desktop-sdk/loading-dashboards.md
@@ -2,8 +2,9 @@
 
 ### Overview & Code
 
-In order to display a dashboard, you must supply its .rdash file as a stream or as a path on the local file system to the constructor of the RVDashboard class
+If you want to display a dashboard, you can choose between loading a __rdash__ file or loading a __json__ file. In both cases the _Build Action_ property of the file has to be set to _Embedded resource_ in Visual Studio.
 
+When you load the dashboard from a __rdash__ file, you have to pass it as stream or path to the _RVDashboard_ constructor.   
 The code snippet below shows how to load a rdash file from a relative path (..\\..\\Sales.rdash):
 
 ``` csharp
@@ -18,9 +19,8 @@ public partial class MainWindow : Window
     private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
     {
         var path = @"..\..\Sales.rdash";
-
         var revealView = new RevealView();
-
+        
         // using a path within the file system
         RVDashboard dashboard = new RVDashboard(path);
 
@@ -36,6 +36,31 @@ public partial class MainWindow : Window
     }
 }
 ```
+When you load a __json__ file, you need to pass the file content as a _string_ parameter to the _RVDashboard.LoadFromJsonAsync_ static method.   
+The code snippet below shows how to load a json file from a relative path (..\\..\\Sales.json):
+``` csharp
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+        this.Loaded += MainWindow_Loaded;
+    }
 
+        private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            var path = @"..\..\Sales.json";
+            var revealView = new RevealView();
+
+            // reading the json file contents
+            string jsonContent = File.ReadAllText(path);
+            RVDashboard dashboard = await RVDashboard.LoadFromJsonAsync(jsonContent);
+            revealView.Dashboard = dashboard;
+
+            Grid grid = this.Content as Grid;
+            grid.Children.Add(revealView);
+        }
+}
+```
 > [!NOTE]
 > In this example, we initialized our component in the *Loaded* event and assumed that the content of the window is a Grid component. You might need to introduce changes when integrating the code into your own application.

--- a/en/developer/desktop-sdk/using-the-desktop-sdk/loading-dashboards.md
+++ b/en/developer/desktop-sdk/using-the-desktop-sdk/loading-dashboards.md
@@ -47,19 +47,19 @@ public partial class MainWindow : Window
         this.Loaded += MainWindow_Loaded;
     }
 
-        private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
-        {
-            var path = @"..\..\Sales.json";
-            var revealView = new RevealView();
+    private async void MainWindow_Loaded(object sender, RoutedEventArgs e)
+    {
+        var path = @"..\..\Sales.json";
+        var revealView = new RevealView();
 
-            // reading the json file contents
-            string jsonContent = File.ReadAllText(path);
-            RVDashboard dashboard = await RVDashboard.LoadFromJsonAsync(jsonContent);
-            revealView.Dashboard = dashboard;
+        // reading the json file contents
+        string jsonContent = File.ReadAllText(path);
+        RVDashboard dashboard = await RVDashboard.LoadFromJsonAsync(jsonContent);
+        revealView.Dashboard = dashboard;
 
-            Grid grid = this.Content as Grid;
-            grid.Children.Add(revealView);
-        }
+        Grid grid = this.Content as Grid;
+        grid.Children.Add(revealView);
+    }
 }
 ```
 > [!NOTE]

--- a/en/developer/web-sdk/using-the-server-sdk/loading-dashboards.md
+++ b/en/developer/web-sdk/using-the-server-sdk/loading-dashboards.md
@@ -11,7 +11,7 @@ There are two ways to open/save dashboards with the SDK:
 
   - **Client-side**: Here you have full control and more flexibility. You provide the stream with the contents of the dashboard on the client page, getting the contents from your own server.
 
-    Using this approach you can, for example, check user permissions, display your own user interface to select the dashboard, or allow users to upload the ".rdash" file to use. For further details about the client-side approach, follow this [**Configuring the RevealView Object**](~/en/developer/web-sdk/using-the-client-sdk/configuring-revealview.md).
+    Using this approach you can, for example, check user permissions, display your own user interface to select the dashboard, or allow users to upload the ".rdash" file to use. For further details about the client-side approach, follow this [**Setup and Configuration(Client)**](~/en/developer/setup-configuration/setup-configuration-web.html#setup-and-configuration-client).
 
 ### The Server-Side Approach
 


### PR DESCRIPTION
The link to "Configuring the RevealView Object." was pointing to a non-existing article. 
Now it opens the "Setup and Configuration (Client)" section in "Setup and configuration(Web)". 
In this section we have an example how to load a dashboard at client-side.
Please, feel free to make comments and suggest improvements.