### PR TITLE
Cloud to local provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _site
 obj
 node_modules/
 .vscode/
+*.dll

--- a/en/developer/desktop-sdk/using-the-desktop-sdk/in-memory-data.md
+++ b/en/developer/desktop-sdk/using-the-desktop-sdk/in-memory-data.md
@@ -51,7 +51,7 @@ Now you need to visualize the dashboard using your own data instead of the dummy
 
 1.  Implement
     __IRVDataSourceProvider__ and set it to the __DataSourceProvider__ property in __RevealSdkSettings__,
-    as described in [**Replacing Data Sources**](replacing-data-sources.md).
+    as described in [**Replacing Data Sources**](replacing-data-sources/replacing-data-sources-mssql.md).
 
     Then, in the implementation for the method __ChangeVisualizationDataSourceItemAsync__, you need to add a code similar to this one:
 

--- a/en/developer/desktop-sdk/using-the-desktop-sdk/replacing-data-sources/replacing-data-sources-excel-csv.md
+++ b/en/developer/desktop-sdk/using-the-desktop-sdk/replacing-data-sources/replacing-data-sources-excel-csv.md
@@ -5,8 +5,6 @@
 When we create a dashboard in **Reveal Application** we often use Excel or CSV files stored in the cloud to populate it with data.   
 After exporting the dashboard and embedding it in custom application, we can move these files in a local directory and then use the **Reveal SDK** to access and set them as a local datasource. 
 
-  > [!NOTE] The *CloudToLocalDatasourceProvider* replaces automatically only Excel and CSV files. They need to be the same as the files used for creating the dashboard. You may change the content of the Excel and CSV datasource files, but the file **schema** has to be the **same**. Calls to any other file types or datasources will remain unchanged.
-
 ### Steps
 To populate the exported dashboard using local Excel and CSV files, you need to follow these steps:
 1. **Export the dashboard** file as explained in [**Getting Dashboards for the SDK**](~/en/developer/general/get-dashboards.md) 
@@ -37,7 +35,7 @@ You can use the *Reveal.Sdk.Samples.UpMedia.Wpf* sample application as reference
         }
         protected Task<RVDataSourceItem> ProcessDataSourceItem(RVDataSourceItem dataSourceItem)
         {
-            // Check if the data source item is excel or csv file. Return the original data source item unchanged if it is not.
+            // Return data source unless it is an excel or csv file.
             if (dataSourceItem is RVExcelDataSourceItem == false &&
                 dataSourceItem is RVCsvDataSourceItem == false)
             {
@@ -54,9 +52,11 @@ You can use the *Reveal.Sdk.Samples.UpMedia.Wpf* sample application as reference
             }
 
             var localItem = new RVLocalFileDataSourceItem();
-            // The SDK replaces the "local:/" string with the local folder name you set as Reveal.SdkSettings.LocalFilesRootFolder
+
+            // The SDK uses the local folder set as Reveal.SdkSettings.LocalFilesRootFolder
             localItem.Uri = @"local:/" + title;
-            // The Title will be displayed as a datasource name in "Dashboard Edit" mode. 
+
+            // The title assigned here is the original data source name. 
             localItem.Title = title;
             resourceBased.ResourceItem = localItem;
 
@@ -65,3 +65,4 @@ You can use the *Reveal.Sdk.Samples.UpMedia.Wpf* sample application as reference
     }
 ```
 
+  > [!NOTE] The *CloudToLocalDatasourceProvider* replaces automatically Excel and CSV files only. Other file types or data sources will remain unchanged. The replacement files should be the same ones used to create the dashboard or, alternatively, new files that share the **same schema** but with different data.

--- a/en/developer/desktop-sdk/using-the-desktop-sdk/replacing-data-sources/replacing-data-sources-excel-csv.md
+++ b/en/developer/desktop-sdk/using-the-desktop-sdk/replacing-data-sources/replacing-data-sources-excel-csv.md
@@ -1,0 +1,67 @@
+## Replacing Excel and CSV file DataSources 
+
+### Overview
+
+When we create a dashboard in **Reveal Application** we often use Excel or CSV files stored in the cloud to populate it with data.   
+After exporting the dashboard and embedding it in custom application, we can move these files in a local directory and then use the **Reveal SDK** to access and set them as a local datasource. 
+
+  > [!NOTE] The *CloudToLocalDatasourceProvider* replaces automatically only Excel and CSV files. They need to be the same as the files used for creating the dashboard. You may change the content of the Excel and CSV datasource files, but the file **schema** has to be the **same**. Calls to any other file types or datasources will remain unchanged.
+
+### Steps
+To populate the exported dashboard using local Excel and CSV files, you need to follow these steps:
+1. **Export the dashboard** file as explained in [**Getting Dashboards for the SDK**](~/en/developer/general/get-dashboards.md) 
+2. **Load the dashboard** in your application as described in: 
+[**Loading Dashboard Files**](~/en/developer/desktop-sdk/using-the-desktop-sdk/loading-dashboards.md) 
+3. **Download the files** you used to create the dashboard from your cloud storage and copy them to a local folder.   
+4. **Set the local folder name** as a value of the *Reveal.SdkSettings.LocalFilesRootFolder* property.   
+You can use the *Reveal.Sdk.Samples.UpMedia.Wpf* sample application as reference for setting *Datasources* as local folder. The sample application comes with **Reveal SDK** installation.  
+5. **Add a new *CloudToLocalDatasourceProvider* class** in the project.  
+6. **Copy the implementation code** from the relevant snippet in **Code** section below.
+7. **Set the *DataSourceProvider* property** of the *RevealSdkContext* class to *CloudToLocalDatasourceProvider*:  
+
+``` csharp
+  public override IRVDataSourceProvider DataSourceProvider => new CloudToLocalDatasourceProvider();        
+```
+
+### Code
+``` csharp
+    public class CloudToLocalDatasourceProvider : IRVDataSourceProvider
+    {
+        public Task<RVDataSourceItem> ChangeDashboardFilterDataSourceItemAsync(RVDashboardFilter filter, RVDataSourceItem dataSourceItem)
+        {
+            return ProcessDataSourceItem(dataSourceItem);
+        }
+        public Task<RVDataSourceItem> ChangeVisualizationDataSourceItemAsync(RVVisualization visualization, RVDataSourceItem dataSourceItem)
+        {
+            return ProcessDataSourceItem(dataSourceItem);
+        }
+        protected Task<RVDataSourceItem> ProcessDataSourceItem(RVDataSourceItem dataSourceItem)
+        {
+            // Check if the data source item is excel or csv file. Return the original data source item unchanged if it is not.
+            if (dataSourceItem is RVExcelDataSourceItem == false &&
+                dataSourceItem is RVCsvDataSourceItem == false)
+            {
+                return Task.FromResult(dataSourceItem);
+            }
+
+            var resourceBased = dataSourceItem as RVResourceBasedDataSourceItem;
+            var resourceItem = resourceBased?.ResourceItem as RVDataSourceItem;
+            var title = resourceItem?.Title;
+
+            if (string.IsNullOrEmpty(title))
+            {
+                return Task.FromResult(dataSourceItem);
+            }
+
+            var localItem = new RVLocalFileDataSourceItem();
+            // The SDK replaces the "local:/" string with the local folder name you set as Reveal.SdkSettings.LocalFilesRootFolder
+            localItem.Uri = @"local:/" + title;
+            // The Title will be displayed as a datasource name in "Dashboard Edit" mode. 
+            localItem.Title = title;
+            resourceBased.ResourceItem = localItem;
+
+            return Task.FromResult(dataSourceItem);
+        }
+    }
+```
+

--- a/en/developer/desktop-sdk/using-the-desktop-sdk/replacing-data-sources/replacing-data-sources-mssql.md
+++ b/en/developer/desktop-sdk/using-the-desktop-sdk/replacing-data-sources/replacing-data-sources-mssql.md
@@ -1,4 +1,4 @@
-## Replacing Data Sources
+## Replacing Data Sources (MS SQL Server)
 
 ### Overview
 

--- a/en/developer/desktop-sdk/using-the-desktop-sdk/replacing-data-sources/toc.yml
+++ b/en/developer/desktop-sdk/using-the-desktop-sdk/replacing-data-sources/toc.yml
@@ -1,0 +1,4 @@
+- name: Microsoft SQL Server Datasource 
+  href: replacing-data-sources-mssql.md
+- name: Excel and CSV files
+  href: replacing-data-sources-excel-csv.md

--- a/en/developer/desktop-sdk/using-the-desktop-sdk/toc.yml
+++ b/en/developer/desktop-sdk/using-the-desktop-sdk/toc.yml
@@ -15,7 +15,7 @@
 - name: Providing Credentials to Data Sources
   href: providing-credentials-datasources.md
 - name: Replacing Data Sources
-  href: replacing-data-sources.md
+  href: replacing-data-sources/toc.yml
 - name: Localizing Dashboards
   href: localization-service.md
 - name: Formatting Dashboards

--- a/en/developer/general/local-files-datasource.md
+++ b/en/developer/general/local-files-datasource.md
@@ -1,0 +1,112 @@
+## Populating exported dashboard with data from local excel and csv files
+
+### Overview
+
+When we create a dashboard in **Reveal Application** we often use Excel or CSV files stored in the cloud to populate it with data.   
+After exporting the dashboard and embedding it in custom application, we can move these files in a local directory and then use the **Reveal SDK** to access and set them as a local datasource. 
+
+### Steps
+To populate the exported dashboard using local Excel and CSV files, you need to follow these steps:
+1. **Export the dashboard** file as explained in [**Getting Dashboards for the SDK**](~/en/developer/general/get-dashboards.md) 
+2. **Load the dashboard** in your application as described in: 
+[**Loading Dashboard Files**](~/en/developer/desktop-sdk/using-the-desktop-sdk/loading-dashboards.md) (for WPF), or 
+[**Creating Your First App**](~/en/developer/web-sdk/create-first-app.md) (for Web)
+3. **Download the files** you used to create the dashboard from your cloud storage and copy them to a local folder.   
+We suggest you use the same folders as in our UpMedia sample application:  
+ - In a WPF application use the *DataSources* folder  
+ - In a Web application use *wwwroot/App_data/RvLocalFiles* folder  
+4. **Add a new *CloudToLocalDatasourceProvider* class** in the project.  
+5. **Copy the implementation code** from the relevant snippet in **Code** section below.
+6. **Set the *DataSourceProvider* property** of the *RevealSdkContext* class to *CloudToLocalDatasourceProvider*:  
+
+``` csharp
+  public override IRVDataSourceProvider DataSourceProvider => new CloudToLocalDatasourceProvider();        
+```
+
+### Code
+CloudToLocalDatasourceProvider for WPF:
+``` csharp
+    public class CloudToLocalDatasourceProvider : IRVDataSourceProvider
+    {
+        public Task<RVDataSourceItem> ChangeDashboardFilterDataSourceItemAsync(RVDashboardFilter filter, RVDataSourceItem dataSourceItem)
+        {
+            return ProcessDataSourceItem(dataSourceItem);
+        }
+        public Task<RVDataSourceItem> ChangeVisualizationDataSourceItemAsync(RVVisualization visualization, RVDataSourceItem dataSourceItem)
+        {
+            return ProcessDataSourceItem(dataSourceItem);
+        }
+        protected Task<RVDataSourceItem> ProcessDataSourceItem(RVDataSourceItem dataSourceItem)
+        {
+            // Check if the data source item is excel or csv file. Return the original data source item unchanged if it is not.
+            if (dataSourceItem is RVExcelDataSourceItem == false &&
+                dataSourceItem is RVCsvDataSourceItem == false)
+            {
+                return Task.FromResult(dataSourceItem);
+            }
+
+            var resourceBased = dataSourceItem as RVResourceBasedDataSourceItem;
+            var resourceItem = resourceBased?.ResourceItem as RVDataSourceItem;
+            var title = resourceItem?.Title;
+
+            if (string.IsNullOrEmpty(title))
+            {
+                return Task.FromResult(dataSourceItem);
+            }
+
+            var localItem = new RVLocalFileDataSourceItem();
+            // add comment what the local folder can be
+            localItem.Uri = @"local:/" + title;
+            // add comment about the title
+            localItem.Title = title;
+            resourceBased.ResourceItem = localItem;
+
+            return Task.FromResult(dataSourceItem);
+        }
+
+    }
+```
+
+CloudToLocalDatasourceProvider for WEB(.Net server side):
+``` csharp
+    public class CloudToLocalDatasourceProvider : IRVDataSourceProvider
+    {
+        public Task<RVDataSourceItem> ChangeDashboardFilterDataSourceItemAsync(string userId, string dashboardId, RVDashboardFilter filter, RVDataSourceItem dataSourceItem)
+        {
+            return ProcessDataSourceItem(dataSourceItem);
+        }
+
+        public Task<RVDataSourceItem> ChangeVisualizationDataSourceItemAsync(string userId, string dashboardId, RVVisualization visualization, RVDataSourceItem dataSourceItem)
+        {
+            return ProcessDataSourceItem(dataSourceItem);
+        }
+
+        protected Task<RVDataSourceItem> ProcessDataSourceItem(RVDataSourceItem dataSourceItem)
+        {
+            // Check if the data source item is excel or csv file. Return the original data source item if not.
+            if (dataSourceItem is RVExcelDataSourceItem == false &&
+                dataSourceItem is RVCsvDataSourceItem == false)
+            {
+                return Task.FromResult(dataSourceItem);
+            }
+
+            var resourceBased = dataSourceItem as RVResourceBasedDataSourceItem;
+            var resourceItem = resourceBased?.ResourceItem as RVDataSourceItem;
+            var title = resourceItem?.Title;
+
+            if (string.IsNullOrEmpty(title))
+            {
+                return Task.FromResult(dataSourceItem);
+            }
+
+            var localItem = new RVLocalFileDataSourceItem();
+            localItem.Uri = @"local:/" + title;
+            localItem.Title = title;
+            resourceBased.ResourceItem = localItem;
+
+            return Task.FromResult(dataSourceItem);
+        }
+    }
+```  
+
+  > [!NOTE] The *CloudToLocalDatasourceProvider* replaces automatically only Excel and CSV files. Files need to be the same as used for creating the dashboard. Calls to any other file types or datasources will remain unchanged. Optionally you may change the content of the excel and csv datasource files, but the file **schema** has to remain the **same**.  In case you use MSSQL database for some visualization, the credentials need to be configured???

--- a/en/developer/toc.yml
+++ b/en/developer/toc.yml
@@ -8,8 +8,6 @@
   href: general/installation-requirements.md
 - name: Getting Dashboards for the SDK
   href: general/get-dashboards.md
-- name: Moving datasource files to Reveal Embedded
-  href: general/local-files-datasource.md 
 - name: WEB .NET SDK
   header: true
 - name: Overview

--- a/en/developer/toc.yml
+++ b/en/developer/toc.yml
@@ -8,6 +8,8 @@
   href: general/installation-requirements.md
 - name: Getting Dashboards for the SDK
   href: general/get-dashboards.md
+- name: Moving datasource files to Reveal Embedded
+  href: general/local-files-datasource.md 
 - name: WEB .NET SDK
   header: true
 - name: Overview

--- a/en/developer/web-sdk/server-sdk.md
+++ b/en/developer/web-sdk/server-sdk.md
@@ -11,6 +11,6 @@ The following table lists the most common scenarios:
 |**Scenario**    |**Details** |
 |---|---|                                                                         
 | [**Loading Dashboard Files**](loading-dashboards.md)                              | You can open/save dashboards either on the server or client-side.                                                |
-| [**Replacing Data Sources**](replacing-data-sources.md)                           | You can override the configuration or data to be used for each visualization of the dashboard.                        |
+| [**Replacing Data Sources**](using-the-server-sdk/replacing-data-sources/replacing-data-sources-mssql.md)                           | You can override the configuration or data to be used for each visualization of the dashboard.                        |
 | [**In-Memory Data Support**](in-memory-data.md)                                   | Data that is part of your application and is already in memory can be used with Reveal SDK.                           |
 | [**Providing Credentials to Data Sources**](providing-credentials-datasources.md) | You can pass in data source credentials when working with SQL Server or OAuth-based data sources.                     |

--- a/en/developer/web-sdk/using-the-server-sdk/in-memory-data.md
+++ b/en/developer/web-sdk/using-the-server-sdk/in-memory-data.md
@@ -69,7 +69,7 @@ Now you need to visualize the dashboard using your own data instead of the dummy
     __IRVDataSourceProvider__
     and return it as the __DataSourceProvider__
     property in
-    __RevealSdkContextBase__, as described in [**Replacing Data Sources**](replacing-data-sources.md).
+    __RevealSdkContextBase__, as described in [**Replacing Data Sources**](replacing-data-sources/replacing-data-sources-mssql.md).
 
     Then, in the implementation for the method
     **ChangeVisualizationDataSourceItemAsync**, you need to add a code similar to this one:

--- a/en/developer/web-sdk/using-the-server-sdk/replacing-data-sources/replacing-data-sources-excel-csv.md
+++ b/en/developer/web-sdk/using-the-server-sdk/replacing-data-sources/replacing-data-sources-excel-csv.md
@@ -1,0 +1,70 @@
+## Replacing Excel and CSV file DataSources
+
+### Overview
+
+When we create a dashboard in **Reveal Application** we often use Excel or CSV files stored in the cloud to populate it with data.   
+After exporting the dashboard and embedding it in custom application, we can move these files in a local directory and then use the **Reveal SDK** to access and set them as a local datasource. 
+  > [!NOTE] The *CloudToLocalDatasourceProvider* replaces automatically only Excel and CSV files. They need to be the same as the files used for creating the dashboard. You may change the content of the Excel and CSV datasource files, but the file **schema** has to be the **same**. Calls to any other file types or datasources will remain unchanged.
+
+### Steps
+To populate the exported dashboard using local Excel and CSV files, you need to follow these steps:
+1. **Export the dashboard** file as explained in [**Getting Dashboards for the SDK**](~/en/developer/general/get-dashboards.md) 
+2. **Load the dashboard** in your application as described in 
+[**Creating Your First App**](~/en/developer/web-sdk/create-first-app.md)
+3. **Download the files** you used to create the dashboard from your cloud storage and copy them to a local folder.  
+4. **Set the local folder name** as a value of the *LocalStoragePath*. Details about this you can find here: [**Setup and Configuration(Server) - Initializing the Server SDK**](~/en/developer/web-sdk/setup-configuration.md#3-initializing-the-server-sdk)  
+5. **Add a new *CloudToLocalDatasourceProvider* class** in the project.  
+6. **Copy the implementation code** from the relevant snippet in **Code** section below.
+7. **Set the *DataSourceProvider* property** of the *RevealSdkContext* class to *CloudToLocalDatasourceProvider*:  
+
+``` csharp
+  public override IRVDataSourceProvider DataSourceProvider => new CloudToLocalDatasourceProvider();        
+```
+
+### Code
+
+``` csharp
+    public class CloudToLocalDatasourceProvider : IRVDataSourceProvider
+    {
+        public Task<RVDataSourceItem> ChangeDashboardFilterDataSourceItemAsync(string userId, string dashboardId, 
+                        RVDashboardFilter filter, RVDataSourceItem dataSourceItem)
+        {
+            return ProcessDataSourceItem(dataSourceItem);
+        }
+
+        public Task<RVDataSourceItem> ChangeVisualizationDataSourceItemAsync(string userId, string dashboardId, 
+                        RVVisualization visualization, RVDataSourceItem dataSourceItem)
+        {
+            return ProcessDataSourceItem(dataSourceItem);
+        }
+
+        protected Task<RVDataSourceItem> ProcessDataSourceItem(RVDataSourceItem dataSourceItem)
+        {
+            // Check if the data source item is excel or csv file. Return the original data source item if not.
+            if (dataSourceItem is RVExcelDataSourceItem == false &&
+                dataSourceItem is RVCsvDataSourceItem == false)
+            {
+                return Task.FromResult(dataSourceItem);
+            }
+
+            var resourceBased = dataSourceItem as RVResourceBasedDataSourceItem;
+            var resourceItem = resourceBased?.ResourceItem as RVDataSourceItem;
+            var title = resourceItem?.Title;
+
+            if (string.IsNullOrEmpty(title))
+            {
+                return Task.FromResult(dataSourceItem);
+            }
+
+            var localItem = new RVLocalFileDataSourceItem();
+            // The SDK replaces the "local:/" string with the local folder name you have set as LocalStoragePath
+            localItem.Uri = @"local:/" + title;
+            // The Title will be displayed as a datasource name in "Dashboard Edit" mode.
+            localItem.Title = title;
+            resourceBased.ResourceItem = localItem;
+
+            return Task.FromResult(dataSourceItem);
+        }
+    }
+```  
+

--- a/en/developer/web-sdk/using-the-server-sdk/replacing-data-sources/replacing-data-sources-excel-csv.md
+++ b/en/developer/web-sdk/using-the-server-sdk/replacing-data-sources/replacing-data-sources-excel-csv.md
@@ -3,8 +3,7 @@
 ### Overview
 
 When we create a dashboard in **Reveal Application** we often use Excel or CSV files stored in the cloud to populate it with data.   
-After exporting the dashboard and embedding it in custom application, we can move these files in a local directory and then use the **Reveal SDK** to access and set them as a local datasource. 
-  > [!NOTE] The *CloudToLocalDatasourceProvider* replaces automatically only Excel and CSV files. They need to be the same as the files used for creating the dashboard. You may change the content of the Excel and CSV datasource files, but the file **schema** has to be the **same**. Calls to any other file types or datasources will remain unchanged.
+After exporting the dashboard and embedding it in custom application, we can move these files in a local directory and then use the **Reveal SDK** to access and set them as a local datasource.
 
 ### Steps
 To populate the exported dashboard using local Excel and CSV files, you need to follow these steps:
@@ -40,7 +39,7 @@ To populate the exported dashboard using local Excel and CSV files, you need to 
 
         protected Task<RVDataSourceItem> ProcessDataSourceItem(RVDataSourceItem dataSourceItem)
         {
-            // Check if the data source item is excel or csv file. Return the original data source item if not.
+            // Return data source unless it is an excel or csv file.
             if (dataSourceItem is RVExcelDataSourceItem == false &&
                 dataSourceItem is RVCsvDataSourceItem == false)
             {
@@ -57,9 +56,11 @@ To populate the exported dashboard using local Excel and CSV files, you need to 
             }
 
             var localItem = new RVLocalFileDataSourceItem();
-            // The SDK replaces the "local:/" string with the local folder name you have set as LocalStoragePath
+
+            // The SDK uses the local folder set as LocalStoragePath.
             localItem.Uri = @"local:/" + title;
-            // The Title will be displayed as a datasource name in "Dashboard Edit" mode.
+
+            // The title assigned here is the original data source name.
             localItem.Title = title;
             resourceBased.ResourceItem = localItem;
 
@@ -67,4 +68,4 @@ To populate the exported dashboard using local Excel and CSV files, you need to 
         }
     }
 ```  
-
+  > [!NOTE] The *CloudToLocalDatasourceProvider* replaces automatically Excel and CSV files only. Other file types or data sources will remain unchanged. The replacement files should be the same ones used to create the dashboard or, alternatively, new files that share the **same schema** but with different data.

--- a/en/developer/web-sdk/using-the-server-sdk/replacing-data-sources/replacing-data-sources-mssql.md
+++ b/en/developer/web-sdk/using-the-server-sdk/replacing-data-sources/replacing-data-sources-mssql.md
@@ -1,4 +1,4 @@
-## Replacing Data Sources
+## Replacing Data Sources (MS SQL Server)
 
 ### Overview
 

--- a/en/developer/web-sdk/using-the-server-sdk/replacing-data-sources/toc.yml
+++ b/en/developer/web-sdk/using-the-server-sdk/replacing-data-sources/toc.yml
@@ -1,0 +1,4 @@
+- name: Microsoft SQL Server Datasource 
+  href: replacing-data-sources-mssql.md
+- name: Excel and CSV files
+  href: replacing-data-sources-excel-csv.md

--- a/en/developer/web-sdk/using-the-server-sdk/toc.yml
+++ b/en/developer/web-sdk/using-the-server-sdk/toc.yml
@@ -1,7 +1,7 @@
 - name: Loading Dashboard Files
   href: loading-dashboards.md
 - name: Replacing Data Sources
-  href: replacing-data-sources.md
+  href: replacing-data-sources/toc.yml
 - name: In-Memory Data Support
   href: in-memory-data.md
 - name: Providing Credentials to Data Sources


### PR DESCRIPTION
Second edition of "Replacing Excel and CSV files" help article.
The left navigation is changed. Now all datasource replacement articles are under "Replacing Datasource" parent node - one for desktop and one for web(server-side).
All the links to the old "Replacing Datasources" article work as expected and point to the MSSql related article.