### PR TITLE
Update the note about using RvealApi.* and $.ig.* prefixes with regard to type definitions

### DIFF
--- a/en/developer/web-sdk/setup-configuration.md
+++ b/en/developer/web-sdk/setup-configuration.md
@@ -227,7 +227,7 @@ Default installation directory is:
 > [!NOTE] **Referencing Reveal JS classes**
 > You could reference the JS classes through **$.ig.** or **RevealApi.**.
 > Through out the docs we're using "$.ig." prefix to reference classes.
-> You could use the RevealApi prefix instead of the "$.ig." one, if you want.
+> You could use the RevealApi prefix instead of the "$.ig." one, if you want. Using **RevealApi** prefix could be better if you're using typescript since you should be able to drop the type definitions(beta) infragistics.reveal.d.ts in your project.
 
 
 <a name='instantiate-web-client-sdk'></a>


### PR DESCRIPTION
Update the note about using RevealApi.* and $.ig.* prefixes. Adding a sentence there about the availability of the RevealApi type definitions as a beta deliverable.
