### PR TITLE
Update user docs/update links

### DIFF
--- a/docs/user/chart-types/choropleth-map.md
+++ b/docs/user/chart-types/choropleth-map.md
@@ -56,7 +56,7 @@ Find more specific information about the Location format and requirements in [Ho
 
 In the example below, we will use a choropleth map to analyse the results of the last presidential elections (2016) in the United States.
 
-To follow this walkthrough, download the [2016 November General Election](../../../static/data/2016_November_General_Election.xlsx) spreadsheet, upload it to a cloud provider and follow the steps below.
+To follow this walkthrough, download the <a href="/data/2016_November_General_Election.xlsx" download>2016 November General Election</a> spreadsheet, upload it to a cloud provider and follow the steps below.
 
 1. Connect to the cloud provider where you uploaded the spreadsheet.
 

--- a/docs/user/fields/calculated/aggregation.md
+++ b/docs/user/fields/calculated/aggregation.md
@@ -22,7 +22,7 @@ In Reveal, aggregation calculated fields include:
 
 :::note
 *All samples included in the table below were created with the
-[HR Dataset 2016](../../../../static/data/HR%20Dataset_2016.xlsx)
+<a href="/data/HR%20Dataset_2016.xlsx" download>HR Dataset 2016</a>
 spreadsheet.*
 :::
 

--- a/docs/user/fields/calculated/logic.md
+++ b/docs/user/fields/calculated/logic.md
@@ -15,7 +15,7 @@ In Reveal, logic calculated fields include:
 
 :::note
 *All samples included in the table below were created with the
-[HR Dataset 2016](../../../../static/data/HR%20Dataset_2016.xlsx)
+<a href="/data/HR%20Dataset_2016.xlsx" download>HR Dataset 2016</a>
 spreadsheet.*
 :::
 

--- a/docs/user/fields/calculated/lookup-reference.md
+++ b/docs/user/fields/calculated/lookup-reference.md
@@ -11,7 +11,7 @@ spreadsheet and dashboard, returning text references to cells, rows and
 dashboard variables.
 
 :::note
-All samples included in the table below were created with the **[HR Dataset 2016](../../../../static/data/HR%20Dataset_2016.xlsx)** spreadsheet.
+All samples included in the table below were created with the **<a href="/data/HR%20Dataset_2016.xlsx" download>HR Dataset 2016</a>** spreadsheet.
 :::
 
 ## Lookup and Reference functions
@@ -36,7 +36,7 @@ for you to configure:
 
 ### Sample
 
-The following is an extract of the [HR Dataset 2016](../../../../static/data/HR%20Dataset_2016.xlsx) "Employees"
+The following is an extract of the <a href="/data/HR%20Dataset_2016.xlsx" download>HR Dataset 2016</a> "Employees"
 sheet.
 
 | EMPLOYEEID | FULLNAME          | DEPARTMENT  | OFFICE                    | WAGE     |

--- a/docs/user/fields/calculated/samples.md
+++ b/docs/user/fields/calculated/samples.md
@@ -11,12 +11,12 @@ The following are a set of calculated field sample expressions.
 
 | Function Name              | Sample Dataset to Test Function        | Expression                                                        | Sample Output                          |
 | -------------------------- |----------------------------------------| ----------------------------------------------------------------- | -------------------------------------- |
-| **Opposite Value**         | [HR Dataset](../../../../static/data/HR%20Dataset_2016.xlsx) | \-[Wage]                                                          | \-36,542.00 (for Joan Baez)            |
-| **Age**                    | [HR Dataset](../../../../static/data/HR%20Dataset_2016.xlsx) | (today()-[BirthDate])/365                                         | 50.13 (for Joan Baez)                  |
-| **Name & Department**      | [HR Dataset](../../../../static/data/HR%20Dataset_2016.xlsx) | [Fullname]& ", " &[Department]                                    | Joan Baez, Development (for Joan Baez) |
-|**Sales Percentage** | [Samples](../../../../static/data/Samples.xlsx)                                       | [New Sales]*100/sum([New Sales]) | 9,26% (for Japan)                    |
-| **Name starts with J**     | [HR Dataset](../../../../static/data/HR%20Dataset_2016.xlsx) | if(find("j",lower([Fullname]),1)=1,"Starts with J",0)             | Starts with J, 0                       |
-| **Deviation from Avg**     | [HR Dataset](../../../../static/data/HR%20Dataset_2016.xlsx) | [Wage]-average([Wage])                                            | \-50476.71 (for Joan Baez)             |
+| **Opposite Value**         | <a href="/data/HR%20Dataset_2016.xlsx" download>HR Dataset</a> | \-[Wage]                                                          | \-36,542.00 (for Joan Baez)            |
+| **Age**                    | <a href="/data/HR%20Dataset_2016.xlsx" download>HR Dataset</a> | (today()-[BirthDate])/365                                         | 50.13 (for Joan Baez)                  |
+| **Name & Department**      | <a href="/data/HR%20Dataset_2016.xlsx" download>HR Dataset</a> | [Fullname]& ", " &[Department]                                    | Joan Baez, Development (for Joan Baez) |
+|**Sales Percentage** | <a href="/data/Samples.xlsx" download>Samples</a>                                       | [New Sales]*100/sum([New Sales]) | 9,26% (for Japan)                    |
+| **Name starts with J**     | <a href="/data/HR%20Dataset_2016.xlsx" download>HR Dataset</a> | if(find("j",lower([Fullname]),1)=1,"Starts with J",0)             | Starts with J, 0                       |
+| **Deviation from Avg**     | <a href="/data/HR%20Dataset_2016.xlsx" download>HR Dataset</a> | [Wage]-average([Wage])                                            | \-50476.71 (for Joan Baez)             |
 
 
 ## Converting Unix TimeStamps to Usable Dates

--- a/docs/user/tutorials-overview.md
+++ b/docs/user/tutorials-overview.md
@@ -2,7 +2,7 @@
 
 Within this section, you will find basic, step-by-step tutorials for the
 Reveal visualizations. All sections use the Data Visualizations data
-source, which you can download using [this link](../../static/data/Reveal_Visualization_Tutorials.xlsx).
+source, which you can download using <a href="/data/Reveal_Visualization_Tutorials.xlsx" download>this link</a>.
 
 | | | | | |
 |:-:|:-:|:-:|:-:|:-:|

--- a/docs/user/visualizations-overview.md
+++ b/docs/user/visualizations-overview.md
@@ -39,7 +39,7 @@ If you need more information about how to use each of these visualizations, use 
 
 ## Visualization Tutorials
 
-Within this section, you will find basic, step-by-step tutorials for the Reveal visualizations. All sections use the Data Visualizations data source, which you can download using [this link](/data/Reveal_Visualization_Tutorials.xlsx).
+Within this section, you will find basic, step-by-step tutorials for the Reveal visualizations. All sections use the Data Visualizations data source, which you can download using <a href="/data/Reveal_Visualization_Tutorials.xlsx" download>this link</a>.
 
 | | | | | |
 |:-:|:-:|:-:|:-:|:-:|


### PR DESCRIPTION
The old linking syntax, for ex: [HR Dataset 2016](../../../../static/data/HR%20Dataset_2016.xlsx) will automatically append a hashed string to the file names

This PR is used to fix this 