### PR TITLE
Update license key from file instructions for clarity

### DIFF
--- a/docs/web/adding-license-key.md
+++ b/docs/web/adding-license-key.md
@@ -15,7 +15,13 @@ The "Home" directory differs depending on the OS you are using.
 - Mac: `/Users/your-user-name/`
 - Linux: `/home/your-user-name/`
 
-When you receive your license key, create a text file named `license.key` within a directory named `.revealbi-sdk` located in your "Home" directory. Populate this file with your license key as its content. Only the key is needed, no quotes and no code. 
+When you receive your license key, create a text file named `license.key` within a directory named `.revealbi-sdk` located in your "Home" directory. Populate this file with your license key as its content.
+
+
+:::note [Contents of Lisense Key File]
+
+Ensure the file contains only the raw license string, without extra code, comments, quotes or formatting. Otherwise, a runtime error on may give a system exception that the file is not a valid Base-64 string.
+:::
 
 For example; if using Windows the license file location should be located at `C:/Users/your-user-name/.revealbi-sdk/license.key`.
 

--- a/docs/web/adding-license-key.md
+++ b/docs/web/adding-license-key.md
@@ -19,7 +19,8 @@ When you receive your license key, create a text file named `license.key` within
 
 :::note [Contents of Lisense Key File]
 
-Ensure the file contains only the raw license string, without extra code, comments, quotes or formatting. Otherwise, a runtime error on may give a system exception that the file is not a valid Base-64 string.
+Make sure the file contains only the raw license string. Do not include any additional code, comments, quotes, or formatting. Otherwise, the application may throw a runtime exception indicating that the file does not contain a valid Base64 string.
+
 :::
 
 For example; if using Windows the license file location should be located at `C:/Users/your-user-name/.revealbi-sdk/license.key`.

--- a/docs/web/adding-license-key.md
+++ b/docs/web/adding-license-key.md
@@ -15,7 +15,7 @@ The "Home" directory differs depending on the OS you are using.
 - Mac: `/Users/your-user-name/`
 - Linux: `/home/your-user-name/`
 
-When you receive your license key, create a text file named `license.key` within a directory named `.revealbi-sdk` located in your "Home" directory. Populate this file with your license key as its content.
+When you receive your license key, create a text file named `license.key` within a directory named `.revealbi-sdk` located in your "Home" directory. Populate this file with your license key as its content. Only the key is needed, no quotes and no code. 
 
 For example; if using Windows the license file location should be located at `C:/Users/your-user-name/.revealbi-sdk/license.key`.
 

--- a/docs/web/adding-license-key.md
+++ b/docs/web/adding-license-key.md
@@ -17,7 +17,6 @@ The "Home" directory differs depending on the OS you are using.
 
 When you receive your license key, create a text file named `license.key` within a directory named `.revealbi-sdk` located in your "Home" directory. Populate this file with your license key as its content.
 
-
 :::note [Contents of Lisense Key File]
 
 Ensure the file contains only the raw license string, without extra code, comments, quotes or formatting. Otherwise, a runtime error on may give a system exception that the file is not a valid Base-64 string.


### PR DESCRIPTION
Clarify instructions for populating the license key from a file. Contents should have the key only, no quotes and no code.