### PR TITLE
Update asset request handler in release notes

### DIFF
--- a/docs/web/release-notes.md
+++ b/docs/web/release-notes.md
@@ -20,7 +20,7 @@ import TabItem from '@theme/TabItem';
 - Data source icons can now be hidden or changed.
 
 ```js
-revealView.Assets.onDataSourceImageRequested = (args) => {
+revealView.onAssetRequested = (args) => {
     // Use default
     return null;
     

--- a/i18n/ja/docusaurus-plugin-content-docs/current/web/release-notes.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/web/release-notes.md
@@ -20,7 +20,7 @@ import TabItem from '@theme/TabItem';
 - Data source icons can now be hidden or changed.
 
 ```js
-revealView.Assets.onDataSourceImageRequested = (args) => {
+revealView.onAssetRequested = (args) => {
     // Use default
     return null;
     


### PR DESCRIPTION
Changed code examples in the release notes to use 'revealView.onAssetRequested' instead of 'revealView.Assets.onDataSourceImageRequested' for clarity and accuracy. Updated both English and Japanese documentation.