### PR TITLE
Document loading dashboards from JSON in Node.js

### DIFF
--- a/docs/web/loading-dashboards.md
+++ b/docs/web/loading-dashboards.md
@@ -341,11 +341,25 @@ This feature is currently not supported by Java
 
   <TabItem value="node" label="Node.js">    
 
-:::danger Unsupported
+Although not directly supported by Node.js, it is possible to emulate the .rdash behaviour from JSON strings.
 
-This feature is currently not supported by Node.js
+```cs
+import JSZip from 'jszip';
+import { Readable } from 'stream';
 
-:::
+export const dashboardProvider = async (userContext, dashboardId) => {
+  // Your JSON string will come from a file, database, etc.
+  const dashboardJson = '{...}';
+
+  // Emulate a .rdash file's contents using JSZip
+  const zip = new JSZip();
+  zip.file('Dashboard.json', dashboardJson);
+  const zipContent = await zip.generateAsync({type: 'nodebuffer'});
+
+  // Return the zip content as a stream
+  return Readable.from(zipContent);
+}
+```
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
While working on our user-defined dashboards I wanted to save them as JSON strings in a database. The docs here said it wasn't supported, and the Reveal AI bot only got halfway in providing an answer, so I thought this might help anyone else looking to implement JSON storage in Node.js

The counterpart to this is the dashboard storage provider, but I couldn't see anywhere suitable in the docs to add that part:

```js
export const dashboardStorageProvider = async (userContext, dashboardId, stream) => {
  // Collect the stream into a buffer
  const chunks = [];
  for await (const chunk of stream) {
    chunks.push(chunk);
  }
  const buffer = Buffer.concat(chunks);

  // Load the zip and extract Dashboard.json
  const zip = await JSZip.loadAsync(buffer);
  const jsonString = await zip.file('Dashboard.json').async('string');

  // save jsonString where needed...
}
```
