### PR TITLE
Add Microsoft Entra ID authentication docs for SQL Server

### DIFF
--- a/docs/web/adding-data-sources/ms-sql-server.md
+++ b/docs/web/adding-data-sources/ms-sql-server.md
@@ -211,6 +211,12 @@ const dataSourceProvider = async (userContext: IRVUserContext | null, dataSource
 
 </Tabs>
 
+:::tip Entra ID Authentication
+
+If you are using Microsoft Entra ID to authenticate against your SQL Server database, see the [Microsoft Entra ID Authentication](../authentication.md#microsoft-entra-id-authentication) section for a complete example.
+
+:::
+
 :::info Get the Code
 
 The source code to this sample can be found on [GitHub](https://github.com/RevealBi/sdk-samples-javascript/tree/main/DataSources/MsSqlServer)

--- a/docs/web/authentication.md
+++ b/docs/web/authentication.md
@@ -319,12 +319,82 @@ The `RVBearerTokenDataSourceCredential` is supported for the following data sour
 - Google Analytics
 - Google Big Query
 - Google Drive
+- Microsoft SQL Server
 - OData Services
 - OneDrive
 - REST Services
 - SharePoint Online
 - Snowflake
 - Web Resources
+
+## Microsoft Entra ID Authentication
+
+Microsoft Entra ID (formerly Azure Active Directory) can be used to obtain bearer tokens for data sources that support Entra ID authentication, such as Microsoft SQL Server. The acquired token is passed to the Reveal SDK using the `RVBearerTokenDataSourceCredential`.
+
+:::info
+
+This example uses the [Microsoft Authentication Library (MSAL)](https://learn.microsoft.com/en-us/entra/msal/overview) for .NET. You must register an application in [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-register-app) and grant it the appropriate database permissions before using this approach.
+
+:::
+
+**Step 1** - Install the `Microsoft.Identity.Client` NuGet package.
+
+```bash
+dotnet add package Microsoft.Identity.Client
+```
+
+**Step 2** - Create the authentication provider that acquires a token from Entra ID and returns it as a `RVBearerTokenDataSourceCredential`.
+
+<Tabs groupId="code" queryString>
+  <TabItem value="aspnet" label="ASP.NET" default>
+
+```cs
+public class AuthenticationProvider : IRVAuthenticationProvider
+{
+    public async Task<IRVDataSourceCredential> ResolveCredentialsAsync(IRVUserContext userContext,
+        RVDashboardDataSource dataSource)
+    {
+        if (dataSource is RVSqlServerDataSource)
+        {
+            var token = await GetEntraTokenAsync("https://database.windows.net/.default");
+            return new RVBearerTokenDataSourceCredential(token, "myaccount@mydomain.com");
+        }
+
+        return new RVUsernamePasswordDataSourceCredential();
+    }
+
+    private static readonly string ClientId = "your-client-id";
+    private static readonly string ClientSecret = "your-client-secret";
+    private static readonly string TenantId = "your-tenant-id";
+
+    private static async Task<string> GetEntraTokenAsync(string scope)
+    {
+        var app = ConfidentialClientApplicationBuilder
+            .Create(ClientId)
+            .WithClientSecret(ClientSecret)
+            .WithAuthority(AzureCloudInstance.AzurePublic, TenantId)
+            .Build();
+
+        var result = await app
+            .AcquireTokenForClient(new[] { scope })
+            .ExecuteAsync();
+
+        return result.AccessToken;
+    }
+}
+```
+
+  </TabItem>
+</Tabs>
+
+:::note
+
+Replace `your-client-id`, `your-client-secret`, and `your-tenant-id` with the values from your Entra ID app registration. The `scope` value `https://database.windows.net/.default` is specific to Azure SQL Server. Other data sources may require a different scope.
+
+:::
+
+Microsoft Entra ID authentication is supported for the following data sources:
+- Microsoft SQL Server
 
 ## Key-Pair Authentication
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/web/adding-data-sources/ms-sql-server.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/web/adding-data-sources/ms-sql-server.md
@@ -211,6 +211,12 @@ const dataSourceProvider = async (userContext: IRVUserContext | null, dataSource
 
 </Tabs>
 
+:::tip Entra ID 認証
+
+Microsoft Entra ID を使用して SQL Server データベースに対して認証を行う場合は、[Microsoft Entra ID 認証](../authentication.md#microsoft-entra-id-認証) セクションで完全な例を参照してください。
+
+:::
+
 :::info コードの取得
 
 このサンプルのソース コードは [GitHub](https://github.com/RevealBi/sdk-samples-javascript/tree/main/DataSources/MsSqlServer) にあります。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/web/authentication.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/web/authentication.md
@@ -318,12 +318,82 @@ const authenticationProvider = async (userContext:IRVUserContext | null, dataSou
 - Google アナリティクス
 - Google Big Query
 - Google Drive
+- Microsoft SQL Server
 - OData サービス
 - OneDrive
 - REST サービス
 - SharePoint オンライン
 - Snowflake
 - ウェブ リソース
+
+## Microsoft Entra ID 認証
+
+Microsoft Entra ID (旧 Azure Active Directory) を使用して、Entra ID 認証をサポートするデータ ソース (Microsoft SQL Server など) のベアラー トークンを取得できます。取得したトークンは、`RVBearerTokenDataSourceCredential` を使用して Reveal SDK に渡されます。
+
+:::info
+
+この例では、.NET 用の [Microsoft Authentication Library (MSAL)](https://learn.microsoft.com/ja-jp/entra/msal/overview) を使用しています。この方法を使用する前に、[Microsoft Entra ID](https://learn.microsoft.com/ja-jp/entra/identity-platform/quickstart-register-app) でアプリケーションを登録し、適切なデータベース権限を付与する必要があります。
+
+:::
+
+**手順 1** - `Microsoft.Identity.Client` NuGet パッケージをインストールします。
+
+```bash
+dotnet add package Microsoft.Identity.Client
+```
+
+**手順 2** - Entra ID からトークンを取得し、`RVBearerTokenDataSourceCredential` として返す認証プロバイダーを作成します。
+
+<Tabs groupId="code" queryString>
+  <TabItem value="aspnet" label="ASP.NET" default>
+
+```cs
+public class AuthenticationProvider : IRVAuthenticationProvider
+{
+    public async Task<IRVDataSourceCredential> ResolveCredentialsAsync(IRVUserContext userContext,
+        RVDashboardDataSource dataSource)
+    {
+        if (dataSource is RVSqlServerDataSource)
+        {
+            var token = await GetEntraTokenAsync("https://database.windows.net/.default");
+            return new RVBearerTokenDataSourceCredential(token, "myaccount@mydomain.com");
+        }
+
+        return new RVUsernamePasswordDataSourceCredential();
+    }
+
+    private static readonly string ClientId = "your-client-id";
+    private static readonly string ClientSecret = "your-client-secret";
+    private static readonly string TenantId = "your-tenant-id";
+
+    private static async Task<string> GetEntraTokenAsync(string scope)
+    {
+        var app = ConfidentialClientApplicationBuilder
+            .Create(ClientId)
+            .WithClientSecret(ClientSecret)
+            .WithAuthority(AzureCloudInstance.AzurePublic, TenantId)
+            .Build();
+
+        var result = await app
+            .AcquireTokenForClient(new[] { scope })
+            .ExecuteAsync();
+
+        return result.AccessToken;
+    }
+}
+```
+
+  </TabItem>
+</Tabs>
+
+:::note
+
+`your-client-id`、`your-client-secret`、`your-tenant-id` を Entra ID アプリ登録の値に置き換えてください。スコープ値 `https://database.windows.net/.default` は Azure SQL Server に固有です。他のデータ ソースでは異なるスコープが必要になる場合があります。
+
+:::
+
+Microsoft Entra ID 認証は、以下のデータ ソースでサポートされます。
+- Microsoft SQL Server
 
 ## キーペア認証
 


### PR DESCRIPTION
## Changes

- Added comprehensive Microsoft Entra ID authentication documentation to `authentication.md`
- Included step-by-step guide with MSAL implementation example for ASP.NET
- Added reference tip in MS SQL Server data source documentation
- Updated supported data sources list to include Microsoft SQL Server for bearer token credentials
- Translated all changes to Japanese documentation (`i18n/ja/`)

## Details

The documentation covers:
- Microsoft Entra ID (formerly Azure Active Directory) token acquisition
- Using `RVBearerTokenDataSourceCredential` with Entra ID tokens
- Complete C# example using Microsoft Authentication Library (MSAL)
- Configuration notes for client ID, secret, and tenant ID
- Scope information for Azure SQL Server authentication