### PR TITLE
Upgrade Guide 2.0

### DIFF
--- a/docs/web/upgrade-guide-v2.0.0.md
+++ b/docs/web/upgrade-guide-v2.0.0.md
@@ -15,7 +15,7 @@ First follow the [1.x upgrade guides in the 1.8.4 documentation](/1.8.4/web/upgr
 - **NPM delivery** — the client SDK is now delivered as an npm package. Legacy script-tag delivery is no longer the recommended approach.
 - **`$.ig` and `RevealApi` namespaces removed** — all types are now imported directly from the `reveal-sdk` npm package. Replace `$.ig.ClassName` and `RevealApi.ClassName` with direct imports (e.g. `import { ClassName } from "reveal-sdk"`).
 - **Renamed and removed APIs** 
-    - `DateFilter` - _removed_ deprecated property from `RevealView`, `RVDashboard`, `RVDateDashboardFilter`, `IExportOptions`, `RevealSettings`, `ExportOptionsBase` and child classes.
+    - `DateFilter` - _removed_ deprecated property from `RevealView`, `RVDashboard`, `RVDateDashboardFilter`, `RevealSettings`, `IExportOptions` and and classes implementing it.
     - `Reveal.Sdk.Dashboard.ToJsonStringAsync` - _renamed_ to `ToJsonString`.
 - **Deprecated types** — `RVDashboardThumbnailView` has been deprecated, in favor of `RVThumbnail`.
 

--- a/docs/web/upgrade-guide-v2.0.0.md
+++ b/docs/web/upgrade-guide-v2.0.0.md
@@ -17,7 +17,7 @@ First follow the [1.x upgrade guides in the 1.8.4 documentation](/1.8.4/web/upgr
 - **Renamed and removed APIs** 
     - `DateFilter` - _removed_ deprecated property from `RevealView`, `RVDashboard`, `RVDateDashboardFilter`, `RevealSettings`, `IExportOptions` and classes implementing it.
     - `Reveal.Sdk.Dashboard.ToJsonStringAsync` - _renamed_ to `ToJsonString`.
-- **Deprecated types** — `RVDashboardThumbnailView` has been deprecated, in favor of `RVThumbnail`.
+- **Deprecated types** — `RVDashboardThumbnailView` has been _deprecated_, in favor of `RVThumbnail`.
 
 ## Step-by-Step Upgrade
 

--- a/docs/web/upgrade-guide-v2.0.0.md
+++ b/docs/web/upgrade-guide-v2.0.0.md
@@ -11,38 +11,216 @@ First follow the [1.x upgrade guides in the 1.8.4 documentation](/1.8.4/web/upgr
 
 ## Overview of Breaking Changes
 
-<!-- TODO: list the high-level breaking changes here so a reader can scan and decide what affects them. -->
+- **jQuery and Day.js removed** — the SDK no longer depends on jQuery or Day.js.
+- **NPM delivery** — the client SDK is now delivered as an npm package; legacy script-tag delivery is no longer the recommended approach.
+- **`$.ig` and `RevealApi` namespaces removed** — all types are now imported directly from the `reveal-sdk` npm package. Replace `$.ig.ClassName` and `RevealApi.ClassName` with direct imports (e.g. `import { ClassName } from "reveal-sdk"`).
+- **Renamed and removed APIs** 
+    - `DateFilter` - _removed_ deprecated property from `RevealView`, `RVDashboard` and `ExportOptionsBase`
+    - `Reveal.Sdk.Dashboard.ToJsonStringAsync` - _renamed_ to `ToJsonString`.
+- **Deprecated types** — `RVDashboardThumbnailView` has been deprecated, in favor of `RVThumbnail`.
 
 ## Step-by-Step Upgrade
 
-### 1. Update package versions
+### 1. Remove jQuery
 
-<!-- TODO: show the new package versions for ASP.NET, Java, and Node SDKs. -->
+The Reveal SDK no longer requires jQuery. Remove the jQuery script tag that was loaded for the SDK:
 
-### 2. Update API usage
+```html
+<!-- Remove this line -->
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
+```
 
-<!-- TODO: list renamed/removed APIs with before/after snippets in tabs. -->
+:::info
+If your own application code depends on jQuery you can keep it — the Reveal SDK simply no longer requires it.
+:::
 
-<Tabs groupId="example">
-    <TabItem value="before" label="1.8.4">
-        ```csharp
-        // before
-        ```
-    </TabItem>
-    <TabItem value="after" label="2.0.0">
-        ```csharp
-        // after
-        ```
-    </TabItem>
+Also remove **Day.js**, **Quill.js** and **Spectrum.js** if they are still present from older versions:
+
+```html
+<!-- Remove these if present -->
+<link href="https://cdnjs.cloudflare.com/ajax/libs/spectrum/1.8.0/spectrum.min.css" rel="stylesheet" type="text/css" >
+<script src="https://cdnjs.cloudflare.com/ajax/libs/spectrum/1.8.0/spectrum.min.js"></script>
+<link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" type="text/css" >
+<script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
+<script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
+```
+
+### 2. Switch client SDK to NPM
+
+Replace the legacy script-tag installation with the npm package.
+
+<Tabs groupId="delivery">
+  <TabItem value="before" label="1.x (script tags)">
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
+<script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
+<script src="https://dl.revealbi.io/reveal/libs/1.8.4/infragistics.reveal.js"></script>
+```
+
+  </TabItem>
+  <TabItem value="after" label="2.0 (npm)">
+
+```bash
+npm install reveal-sdk
+```
+
+```typescript
+import { RevealSdkSettings, RevealView } from "reveal-sdk";
+```
+
+  </TabItem>
 </Tabs>
 
-### 3. Update configuration
+:::tip Still need script tags?
+The SDK distribution zip is still available for non-bundler setups — jQuery and Day.js are no longer needed:
 
-<!-- TODO: any config / appsettings / DI changes go here. -->
+```html
+<script src="./assets/reveal/reveal-sdk.js"></script>
+```
+:::
+
+:::info Full installation guides
+For a deeper dive into all client SDK installation options — including CDN with ES modules, npm with Angular, and npm with React — see the [Installation Guide](installation/installation.md).
+:::
+
+### 3. Update server SDK packages
+
+<Tabs groupId="code" queryString>
+  <TabItem value="aspnet" label="ASP.NET" default>
+
+Update the `Reveal.Sdk.*` NuGet packages to version **2.0.0** or later.
+
+```xml
+<PackageReference Include="Reveal.Sdk.AspNetCore" Version="2.0.0" />
+```
+
+  </TabItem>
+  <TabItem value="java" label="Java">
+
+Update your Maven/Gradle dependency to version **2.0.0** or later.
+
+```xml
+<dependency>
+    <groupId>com.infragistics.reveal.sdk</groupId>
+    <artifactId>reveal-sdk</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+  </TabItem>
+  <TabItem value="node" label="Node.js">
+
+```bash
+npm install reveal-sdk-node@2.0.0
+```
+
+  </TabItem>
+</Tabs>
+
+### 4. Update API usage
+
+#### `$.ig` / `RevealApi` → Direct imports
+
+The `$.ig` and `RevealApi` global namespaces have been removed. All types are now imported directly from the `reveal-sdk` npm package. If you were using TypeScript with `infragistics.reveal.d.ts` for IntelliSense (e.g. `new $.ig.RevealView`), update all references to use direct imports instead.
+
+<Tabs groupId="api-namespace">
+  <TabItem value="before" label="1.x">
+
+```javascript
+$.ig.RevealSdkSettings.setBaseUrl("https://localhost:5111/");
+var revealView = new $.ig.RevealView("#revealView");
+```
+
+  </TabItem>
+  <TabItem value="after" label="2.0">
+
+```typescript
+import { RevealSdkSettings, RevealView } from "reveal-sdk";
+
+RevealSdkSettings.setBaseUrl("https://localhost:5111/");
+const revealView = new RevealView("#revealView");
+```
+
+  </TabItem>
+</Tabs>
+
+#### `DateFilter` → `filters` + `RVDateRule`
+
+The deprecated `DateFilter` property has been removed. Use the `filters` collection instead.  DateFilter was eliminated from `RevealView`, `RVDashboard`, `RVDateDashboardFilter`, `IExportOptions`, `RevealSettings`, `ExportOptionsBase` and child classes.
+
+<Tabs groupId="api-datefilter">
+  <TabItem value="before" label="1.x">
+
+```javascript
+var myRule = new $.ig.RVDateRule($.ig.RVPeriodRelation.Last, 3, $.ig.RVPeriodType.Month);
+dashboard.dateFilter = new $.ig.RVDateDashboardFilter(myRule);
+```
+
+  </TabItem>
+  <TabItem value="after" label="2.0">
+
+```typescript
+import { RVDateRule, RVPeriodRelation, RVPeriodType } from "reveal-sdk";
+
+const myRule = new RVDateRule(RVPeriodRelation.Last, 3, RVPeriodType.Month);
+const myDateFilter = dashboard.filters.findByTitle("My Date Filter");
+myDateFilter.rule = myRule;
+```
+
+  </TabItem>
+</Tabs>
+
+#### `RVDashboardThumbnailView` → `RVThumbnail`
+
+<Tabs groupId="api-thumbnail">
+  <TabItem value="before" label="1.x">
+
+```javascript
+var thumbnailView = new $.ig.RevealDashboardThumbnailView("#thumbnail");
+$.ig.RevealUtility.getDashboardInfo("Sales", function (info) {
+  thumbnailView.dashboardInfo = info.info;
+});
+```
+
+  </TabItem>
+  <TabItem value="after" label="2.0">
+
+```typescript
+import { RVThumbnail } from "reveal-sdk";
+
+RVThumbnail.fromDashboard("#thumbnail", "Sales");
+```
+
+  </TabItem>
+</Tabs>
+
+The new `RVThumbnail` API also supports runtime theme changes.
 
 ## Removed APIs
 
-<!-- TODO: list APIs removed in 2.0 with the recommended replacement. -->
+| API | Replacement |
+|---|---|
+| `$.ig` namespace | Direct imports from `reveal-sdk` |
+| `RevealApi` namespace | Direct imports from `reveal-sdk` |
+| `DateFilter` property | `filters` collection |
+| `RVDashboardThumbnailView` | `RVThumbnail` |
+| `Reveal.Sdk.Dashboard.ToJsonStringAsync` | `ToJsonString` |
+| Legacy chart types (previously deprecated) | Use current [Chart Types](/web/chart-types) |
+| Legacy Java engine | Java SDK (Spring Boot) |
+
+## Summary Checklist
+
+- [ ] Remove jQuery `<script>` tag
+- [ ] Remove Quill.js and Spectrum.js references if still present
+- [ ] Switch client SDK to npm package (or remove jQuery from script-tag setup)
+- [ ] Update server SDK packages to 2.0.0
+- [ ] Replace `$.ig.` and `RevealApi.` with direct imports from `reveal-sdk` in all client code
+- [ ] Replace uses of `DateFilter` property to use `Filters` list instead.
+- [ ] Replace `RVDashboardThumbnailView` with `RVThumbnail`
+- [ ] Replace `Reveal.Sdk.Dashboard.ToJsonStringAsync` with `ToJsonString`
+- [ ] Verify no dashboards use removed legacy chart types
+- [ ] If using the legacy Java engine, migrate to a supported server SDK
 
 ## Need help?
 

--- a/docs/web/upgrade-guide-v2.0.0.md
+++ b/docs/web/upgrade-guide-v2.0.0.md
@@ -12,7 +12,7 @@ First follow the [1.x upgrade guides in the 1.8.4 documentation](/1.8.4/web/upgr
 ## Overview of Breaking Changes
 
 - **jQuery and Day.js removed** — the SDK no longer depends on jQuery or Day.js.
-- **NPM delivery** — the client SDK is now delivered as an npm package; legacy script-tag delivery is no longer the recommended approach.
+- **NPM delivery** — the client SDK is now delivered as an npm package. Legacy script-tag delivery is no longer the recommended approach.
 - **`$.ig` and `RevealApi` namespaces removed** — all types are now imported directly from the `reveal-sdk` npm package. Replace `$.ig.ClassName` and `RevealApi.ClassName` with direct imports (e.g. `import { ClassName } from "reveal-sdk"`).
 - **Renamed and removed APIs** 
     - `DateFilter` - _removed_ deprecated property from `RevealView`, `RVDashboard` and `ExportOptionsBase`

--- a/docs/web/upgrade-guide-v2.0.0.md
+++ b/docs/web/upgrade-guide-v2.0.0.md
@@ -143,7 +143,7 @@ const revealView = new RevealView("#revealView");
 
 #### `DateFilter` → `filters` + `RVDateRule`
 
-The deprecated `DateFilter` property has been removed. Use the `filters` collection instead.  DateFilter was eliminated from `RevealView`, `RVDashboard`, `RVDateDashboardFilter`, `RevealSettings`, `IExportOptions` and and classes implementing it.
+The deprecated `DateFilter` property has been removed. Use the `filters` collection instead.  DateFilter was eliminated from `RevealView`, `RVDashboard`, `RVDateDashboardFilter`, `RevealSettings`, `IExportOptions` and classes implementing it.
 
 <Tabs groupId="api-datefilter">
   <TabItem value="before" label="1.x">

--- a/docs/web/upgrade-guide-v2.0.0.md
+++ b/docs/web/upgrade-guide-v2.0.0.md
@@ -143,7 +143,7 @@ const revealView = new RevealView("#revealView");
 
 #### `DateFilter` → `filters` + `RVDateRule`
 
-The deprecated `DateFilter` property has been removed. Use the `filters` collection instead.  DateFilter was eliminated from `RevealView`, `RVDashboard`, `RVDateDashboardFilter`, `IExportOptions`, `RevealSettings`, `ExportOptionsBase` and child classes.
+The deprecated `DateFilter` property has been removed. Use the `filters` collection instead.  DateFilter was eliminated from `RevealView`, `RVDashboard`, `RVDateDashboardFilter`, `RevealSettings`, `IExportOptions` and and classes implementing it.
 
 <Tabs groupId="api-datefilter">
   <TabItem value="before" label="1.x">

--- a/docs/web/upgrade-guide-v2.0.0.md
+++ b/docs/web/upgrade-guide-v2.0.0.md
@@ -23,7 +23,7 @@ First follow the [1.x upgrade guides in the 1.8.4 documentation](/1.8.4/web/upgr
 
 ### 1. Remove jQuery
 
-The Reveal SDK no longer requires jQuery. Remove the jQuery script tag that was loaded for the SDK:
+The Reveal SDK no longer requires jQuery. Remove the jQuery script tag that was previously required by the SDK:
 
 ```html
 <!-- Remove this line -->

--- a/docs/web/upgrade-guide-v2.0.0.md
+++ b/docs/web/upgrade-guide-v2.0.0.md
@@ -169,6 +169,8 @@ myDateFilter.rule = myRule;
 
 #### `RVDashboardThumbnailView` → `RVThumbnail`
 
+Usage of `RVDashboardThumbnailView` is being deprecated. The class will continue to be available for some time, but we recommend that you migrate your code to use `RVThumbnail` instead.
+
 <Tabs groupId="api-thumbnail">
   <TabItem value="before" label="1.x">
 

--- a/docs/web/upgrade-guide-v2.0.0.md
+++ b/docs/web/upgrade-guide-v2.0.0.md
@@ -15,7 +15,7 @@ First follow the [1.x upgrade guides in the 1.8.4 documentation](/1.8.4/web/upgr
 - **NPM delivery** — the client SDK is now delivered as an npm package. Legacy script-tag delivery is no longer the recommended approach.
 - **`$.ig` and `RevealApi` namespaces removed** — all types are now imported directly from the `reveal-sdk` npm package. Replace `$.ig.ClassName` and `RevealApi.ClassName` with direct imports (e.g. `import { ClassName } from "reveal-sdk"`).
 - **Renamed and removed APIs** 
-    - `DateFilter` - _removed_ deprecated property from `RevealView`, `RVDashboard`, `RVDateDashboardFilter`, `RevealSettings`, `IExportOptions` and and classes implementing it.
+    - `DateFilter` - _removed_ deprecated property from `RevealView`, `RVDashboard`, `RVDateDashboardFilter`, `RevealSettings`, `IExportOptions` and classes implementing it.
     - `Reveal.Sdk.Dashboard.ToJsonStringAsync` - _renamed_ to `ToJsonString`.
 - **Deprecated types** — `RVDashboardThumbnailView` has been deprecated, in favor of `RVThumbnail`.
 

--- a/docs/web/upgrade-guide-v2.0.0.md
+++ b/docs/web/upgrade-guide-v2.0.0.md
@@ -215,7 +215,7 @@ The new `RVThumbnail` API also supports runtime theme changes.
 - [ ] Update server SDK packages to 2.0.0
 - [ ] Replace `$.ig.` and `RevealApi.` with direct imports from `reveal-sdk` in all client code
 - [ ] Replace uses of `DateFilter` property to use `Filters` list instead.
-- [ ] Replace `RVDashboardThumbnailView` with `RVThumbnail`
+- [ ] (recommended) Replace `RVDashboardThumbnailView` with `RVThumbnail`
 - [ ] Replace `Reveal.Sdk.Dashboard.ToJsonStringAsync` with `ToJsonString`
 - [ ] Verify no dashboards use removed legacy chart types
 - [ ] If using the legacy Java engine, migrate to a supported server SDK

--- a/docs/web/upgrade-guide-v2.0.0.md
+++ b/docs/web/upgrade-guide-v2.0.0.md
@@ -80,9 +80,6 @@ The SDK distribution zip is still available for non-bundler setups — jQuery an
 ```
 :::
 
-:::info Full installation guides
-For a deeper dive into all client SDK installation options — including CDN with ES modules, npm with Angular, and npm with React — see the [Installation Guide](installation/installation.md).
-:::
 
 ### 3. Update server SDK packages
 

--- a/docs/web/upgrade-guide-v2.0.0.md
+++ b/docs/web/upgrade-guide-v2.0.0.md
@@ -80,7 +80,6 @@ The SDK distribution zip is still available for non-bundler setups — jQuery an
 ```
 :::
 
-
 ### 3. Update server SDK packages
 
 <Tabs groupId="code" queryString>

--- a/docs/web/upgrade-guide-v2.0.0.md
+++ b/docs/web/upgrade-guide-v2.0.0.md
@@ -15,7 +15,7 @@ First follow the [1.x upgrade guides in the 1.8.4 documentation](/1.8.4/web/upgr
 - **NPM delivery** — the client SDK is now delivered as an npm package. Legacy script-tag delivery is no longer the recommended approach.
 - **`$.ig` and `RevealApi` namespaces removed** — all types are now imported directly from the `reveal-sdk` npm package. Replace `$.ig.ClassName` and `RevealApi.ClassName` with direct imports (e.g. `import { ClassName } from "reveal-sdk"`).
 - **Renamed and removed APIs** 
-    - `DateFilter` - _removed_ deprecated property from `RevealView`, `RVDashboard` and `ExportOptionsBase`
+    - `DateFilter` - _removed_ deprecated property from `RevealView`, `RVDashboard`, `RVDateDashboardFilter`, `IExportOptions`, `RevealSettings`, `ExportOptionsBase` and child classes.
     - `Reveal.Sdk.Dashboard.ToJsonStringAsync` - _renamed_ to `ToJsonString`.
 - **Deprecated types** — `RVDashboardThumbnailView` has been deprecated, in favor of `RVThumbnail`.
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current.json
+++ b/i18n/ja/docusaurus-plugin-content-docs/current.json
@@ -720,7 +720,7 @@
     "description": "The label for the doc item 'Cosmos DB' in sidebar 'webSidebar', linking to the doc web/adding-data-sources/azure-cosmos-db"
   },
   "sidebar.webSidebar.doc.2.0.0 Upgrade Guide": {
-    "message": "2.0.0 Upgrade Guide",
+    "message": "2.0.0 アップグレード ガイド",
     "description": "The label for the doc item '2.0.0 Upgrade Guide' in sidebar 'webSidebar', linking to the doc web/upgrade-guide-v2.0.0"
   }
 }

--- a/i18n/ja/docusaurus-plugin-content-docs/current/web/upgrade-guide-v2.0.0.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/web/upgrade-guide-v2.0.0.md
@@ -1,0 +1,227 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# 2.0.0 へのアップグレード
+
+このガイドでは、Reveal SDK 2.0 で導入された破壊的変更と、既存の 1.x アプリケーションを 2.0 にアップグレードするために必要な手順について説明します。
+
+:::note 1.8.4 より前のバージョンをお使いですか?
+まず [1.x アップグレード ガイド (1.8.4 ドキュメント)](/1.8.4/web/upgrade-guide-v1.6.0/) に従ってプロジェクトを 1.8.4 にアップグレードしてから、このページに戻って 2.0 への移行を完了してください。
+:::
+
+## 破壊的変更の概要
+
+- **jQuery と Day.js の削除** — SDK は jQuery と Day.js に依存しなくなりました。
+- **NPM 配信** — クライアント SDK は npm パッケージとして配信されるようになりました。レガシーなスクリプトタグによる配信は推奨されなくなりました。
+- **`$.ig` と `RevealApi` 名前空間の削除** — すべての型は `reveal-sdk` npm パッケージから直接インポートするようになりました。`$.ig.ClassName` および `RevealApi.ClassName` を直接インポートに置き換えてください (例: `import { ClassName } from "reveal-sdk"`)。
+- **API の名前変更と削除** 
+    - `DateFilter` - _削除_ `RevealView`、`RVDashboard`、`ExportOptionsBase` から非推奨プロパティを削除
+    - `Reveal.Sdk.Dashboard.ToJsonStringAsync` - _名前変更_ `ToJsonString` に変更。
+- **非推奨の型** — `RVDashboardThumbnailView` は非推奨になりました。`RVThumbnail` を使用してください。
+
+## アップグレード手順
+
+### 1. jQuery を削除する
+
+Reveal SDK は jQuery を必要としなくなりました。SDK のためにロードしていた jQuery のスクリプトタグを削除してください:
+
+```html
+<!-- この行を削除 -->
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
+```
+
+:::info
+アプリケーション自体のコードが jQuery に依存している場合はそのまま使用できます — Reveal SDK が jQuery を必要としなくなっただけです。
+:::
+
+また、古いバージョンから残っている **Day.js**、**Quill.js**、**Spectrum.js** も削除してください:
+
+```html
+<!-- これらがある場合は削除 -->
+<link href="https://cdnjs.cloudflare.com/ajax/libs/spectrum/1.8.0/spectrum.min.css" rel="stylesheet" type="text/css" >
+<script src="https://cdnjs.cloudflare.com/ajax/libs/spectrum/1.8.0/spectrum.min.js"></script>
+<link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet" type="text/css" >
+<script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
+<script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
+```
+
+### 2. クライアント SDK を NPM に切り替える
+
+レガシーなスクリプトタグによるインストールを npm パッケージに置き換えます。
+
+<Tabs groupId="delivery">
+  <TabItem value="before" label="1.x (スクリプトタグ)">
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
+<script src="https://unpkg.com/dayjs@1.8.21/dayjs.min.js"></script>
+<script src="https://dl.revealbi.io/reveal/libs/1.8.4/infragistics.reveal.js"></script>
+```
+
+  </TabItem>
+  <TabItem value="after" label="2.0 (npm)">
+
+```bash
+npm install reveal-sdk
+```
+
+```typescript
+import { RevealSdkSettings, RevealView } from "reveal-sdk";
+```
+
+  </TabItem>
+</Tabs>
+
+:::tip スクリプトタグが必要ですか?
+バンドラーを使用しない環境向けに SDK 配布 zip は引き続き利用可能ですが、jQuery と Day.js は不要になりました:
+
+```html
+<script src="./assets/reveal/reveal-sdk.js"></script>
+```
+:::
+
+:::info インストール ガイド
+CDN + ES Modules、Angular での npm、React での npm など、クライアント SDK のインストール方法を詳しく確認する場合は、[インストール ガイド](installation/installation.md) を参照してください。
+:::
+
+### 3. サーバー SDK パッケージを更新する
+
+<Tabs groupId="code" queryString>
+  <TabItem value="aspnet" label="ASP.NET" default>
+
+`Reveal.Sdk.*` NuGet パッケージをバージョン **2.0.0** 以降に更新します。
+
+```xml
+<PackageReference Include="Reveal.Sdk.AspNetCore" Version="2.0.0" />
+```
+
+  </TabItem>
+  <TabItem value="java" label="Java">
+
+Maven/Gradle の依存関係をバージョン **2.0.0** 以降に更新します。
+
+```xml
+<dependency>
+    <groupId>com.infragistics.reveal.sdk</groupId>
+    <artifactId>reveal-sdk</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+  </TabItem>
+  <TabItem value="node" label="Node.js">
+
+```bash
+npm install reveal-sdk-node@2.0.0
+```
+
+  </TabItem>
+</Tabs>
+
+### 4. API の使用方法を更新する
+
+#### `$.ig` / `RevealApi` → 直接インポート
+
+`$.ig` と `RevealApi` のグローバル名前空間は削除されました。すべての型は `reveal-sdk` npm パッケージから直接インポートするようになりました。TypeScript で `infragistics.reveal.d.ts` を使用して IntelliSense を利用していた場合 (例: `new $.ig.RevealView`)、すべての参照を直接インポートに更新してください。
+
+<Tabs groupId="api-namespace">
+  <TabItem value="before" label="1.x">
+
+```javascript
+$.ig.RevealSdkSettings.setBaseUrl("https://localhost:5111/");
+var revealView = new $.ig.RevealView("#revealView");
+```
+
+  </TabItem>
+  <TabItem value="after" label="2.0">
+
+```typescript
+import { RevealSdkSettings, RevealView } from "reveal-sdk";
+
+RevealSdkSettings.setBaseUrl("https://localhost:5111/");
+const revealView = new RevealView("#revealView");
+```
+
+  </TabItem>
+</Tabs>
+
+#### `DateFilter` → `filters` + `RVDateRule`
+
+非推奨の `DateFilter` プロパティは削除されました。代わりに `filters` コレクションを使用してください。  DateFilter は `RevealView`、`RVDashboard`、`RVDateDashboardFilter`、`IExportOptions`、`RevealSettings`、`ExportOptionsBase` およびその子クラスから削除されました。
+
+<Tabs groupId="api-datefilter">
+  <TabItem value="before" label="1.x">
+
+```javascript
+var myRule = new $.ig.RVDateRule($.ig.RVPeriodRelation.Last, 3, $.ig.RVPeriodType.Month);
+dashboard.dateFilter = new $.ig.RVDateDashboardFilter(myRule);
+```
+
+  </TabItem>
+  <TabItem value="after" label="2.0">
+
+```typescript
+import { RVDateRule, RVPeriodRelation, RVPeriodType } from "reveal-sdk";
+
+const myRule = new RVDateRule(RVPeriodRelation.Last, 3, RVPeriodType.Month);
+const myDateFilter = dashboard.filters.findByTitle("My Date Filter");
+myDateFilter.rule = myRule;
+```
+
+  </TabItem>
+</Tabs>
+
+#### `RVDashboardThumbnailView` → `RVThumbnail`
+
+<Tabs groupId="api-thumbnail">
+  <TabItem value="before" label="1.x">
+
+```javascript
+var thumbnailView = new $.ig.RevealDashboardThumbnailView("#thumbnail");
+$.ig.RevealUtility.getDashboardInfo("Sales", function (info) {
+  thumbnailView.dashboardInfo = info.info;
+});
+```
+
+  </TabItem>
+  <TabItem value="after" label="2.0">
+
+```typescript
+import { RVThumbnail } from "reveal-sdk";
+
+RVThumbnail.fromDashboard("#thumbnail", "Sales");
+```
+
+  </TabItem>
+</Tabs>
+
+新しい `RVThumbnail` API はランタイムでのテーマ変更もサポートしています。
+
+## 削除された API
+
+| API | 代替 |
+|---|---|
+| `$.ig` 名前空間 | `reveal-sdk` からの直接インポート |
+| `RevealApi` 名前空間 | `reveal-sdk` からの直接インポート |
+| `DateFilter` プロパティ | `filters` コレクション |
+| `RVDashboardThumbnailView` | `RVThumbnail` |
+| `Reveal.Sdk.Dashboard.ToJsonStringAsync` | `ToJsonString` |
+| レガシー チャート タイプ (以前に非推奨) | 現在の[チャート タイプ](/web/chart-types)を使用 |
+| レガシー Java エンジン | Java SDK (Spring Boot) |
+
+## チェックリスト
+
+- [ ] jQuery の `<script>` タグを削除
+- [ ] Quill.js と Spectrum.js の参照がある場合は削除
+- [ ] クライアント SDK を npm パッケージに切り替え (またはスクリプトタグ構成から jQuery を削除)
+- [ ] サーバー SDK パッケージを 2.0.0 に更新
+- [ ] すべてのクライアントコードで `$.ig.` と `RevealApi.` を `reveal-sdk` からの直接インポートに置き換え
+- [ ] `DateFilter` プロパティの使用を `Filters` リストで置き換え
+- [ ] `RVDashboardThumbnailView` を `RVThumbnail` に置き換え
+- [ ] `Reveal.Sdk.Dashboard.ToJsonStringAsync` を `ToJsonString` に置き換え
+- [ ] 削除されたレガシー チャート タイプを使用しているダッシュボードがないことを確認
+- [ ] レガシー Java エンジンを使用している場合は、サポートされているサーバー SDK に移行
+
+## お困りですか?
+
+アップグレード中に問題が発生した場合は、[Issue を作成する](https://github.com/RevealBi/Reveal.Sdk/issues)か、アプリ内チャットからお問い合わせください。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/web/upgrade-guide-v2.0.0.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/web/upgrade-guide-v2.0.0.md
@@ -80,9 +80,6 @@ import { RevealSdkSettings, RevealView } from "reveal-sdk";
 ```
 :::
 
-:::info インストール ガイド
-CDN + ES Modules、Angular での npm、React での npm など、クライアント SDK のインストール方法を詳しく確認する場合は、[インストール ガイド](installation/installation.md) を参照してください。
-:::
 
 ### 3. サーバー SDK パッケージを更新する
 


### PR DESCRIPTION
- All "2.0" tab code blocks now use import { ... } from "reveal-sdk" with direct type usage (no Reveal. prefix)
- Changed var to const in the new TypeScript examples
- Changed code fence language from javascript to typescript
- Updated descriptive text, section headings, Removed APIs table, and Summary Checklist to reference direct imports instead of the Reveal namespace