### PR TITLE
Update documentation for custom providers to include support for Java

### DIFF
--- a/docs/ai/providers-building-custom.md
+++ b/docs/ai/providers-building-custom.md
@@ -222,7 +222,7 @@ builder.Services.AddRevealAI()
 
 ## Java: Custom Providers via Callbacks
 
-In Java, custom providers are not implemented as `IAIProvider` classes. Instead, you register a **callback** with the `RevealAIPlugin` that receives the prompt request as JSON and returns the response as JSON. The plugin bridges the callback to the underlying AI engine.
+To implement a custom provider, register a **callback** with the `RevealAIPlugin` that receives the prompt request as JSON and returns the response as JSON. The plugin bridges the callback to the underlying AI engine.
 
 ### Registration Conventions
 
@@ -310,7 +310,7 @@ Real callbacks should parse the incoming JSON (for example with Jackson) to read
 
 ## Node.js: Custom Providers via Callbacks
 
-Node.js uses the same callback-based mechanism as Java. You supply a callback (or a map of named callbacks) to the AI plugin options; each callback receives the request as a JSON string and returns the response as a JSON string.
+You supply a callback (or a map of named callbacks) to the AI plugin options; each callback receives the request as a JSON string and returns the response as a JSON string.
 
 ### Registration Conventions
 

--- a/docs/ai/providers-building-custom.md
+++ b/docs/ai/providers-building-custom.md
@@ -5,11 +5,17 @@ sidebar_label: Building a Custom Provider
 
 # Building a Custom Provider
 
-If you need to integrate with an LLM service that isn't supported out of the box, you can create a custom provider by implementing the `IAIProvider` interface and registering it with the SDK.
+If you need to integrate with an LLM service that isn't supported out of the box, you can create a custom provider and register it with the SDK.
 
-:::info ASP.NET Core only
+:::info Platform support
 
-Custom providers built against the `IAIProvider` interface are currently supported on **ASP.NET Core** only. Node.js and Java applications must use one of the built-in providers — if your target service exposes an OpenAI-compatible API, use the [Custom Endpoints](providers-custom-endpoints.md) approach with the OpenAI provider.
+The approach depends on your server platform:
+
+- **ASP.NET Core** - implement the `IAIProvider` interface and register it with `AddProvider` (covered below).
+- **Java** - register a callback with the `RevealAIPlugin` (see [Java: Custom Providers via Callbacks](#java-custom-providers-via-callbacks)).
+- **Node.js** - register a callback with the AI plugin options (see [Node.js: Custom Providers via Callbacks](#nodejs-custom-providers-via-callbacks)).
+
+If your target service exposes an OpenAI-compatible API, you can also use the [Custom Endpoints](providers-custom-endpoints.md) approach with the OpenAI provider on any platform.
 
 :::
 
@@ -112,7 +118,7 @@ builder.Services.AddRevealAI()
     });
 ```
 
-The first parameter is the **provider key** — a unique string identifier used to resolve the provider. The second parameter is a factory function that receives the `IServiceProvider` for dependency injection.
+The first parameter is the **provider key** - a unique string identifier used to resolve the provider. The second parameter is a factory function that receives the `IServiceProvider` for dependency injection.
 
 ## Step 3: Set as Default (Optional)
 
@@ -212,4 +218,129 @@ builder.Services.AddRevealAI()
     {
         return new MyCustomProvider(/* ... */);
     });
+```
+
+## Java: Custom Providers via Callbacks
+
+In Java, custom providers are not implemented as `IAIProvider` classes. Instead, you register a **callback** with the `RevealAIPlugin` that receives the prompt request as JSON and returns the response as JSON. The plugin bridges the callback to the underlying AI engine.
+
+### Registration Conventions
+
+Callbacks are registered by key in the `Map<String, RevealPluginCallback>` you pass to `RevealAIPlugin.withOptions(options, callbacks)`:
+
+| Key | Behavior |
+|-----|----------|
+| `aiProvider` | Registers a single custom provider. It is selectable under the reserved name `CustomAIProvider`. |
+| `aiProvider:<key>` | Registers a **named** provider. `<key>` (e.g. `my-custom-provider`) becomes a selectable provider/model name. You can register multiple named providers. |
+
+:::warning Reserved name
+
+`CustomAIProvider` is reserved. Passing `aiProvider:CustomAIProvider` throws an `IllegalArgumentException`.
+
+:::
+
+### Callback Signature
+
+A provider callback implements `RevealPluginCallback`:
+
+```java
+@FunctionalInterface
+public interface RevealPluginCallback {
+    CompletableFuture<String> invoke(IRVUserContext userContext, String message);
+}
+```
+
+- **`message`** - a JSON-serialized request with the following fields:
+
+  | Field | Type | Description |
+  |-------|------|-------------|
+  | `prompt` | string | The prompt to send to the LLM. |
+  | `intent` | string | The intent of the request (e.g. `"default"`). |
+  | `model` | string \| null | Optional model override. If `null`, use your provider's default. |
+
+- **Return value** - a JSON-serialized response with the following fields:
+
+  | Field | Type | Description |
+  |-------|------|-------------|
+  | `content` | string | The generated text content. |
+  | `finishReason` | string | Why generation stopped: `Stop`, `Length`, or `ContentFilter`. |
+  | `usage` | object \| null | Optional token usage: `{ "inputTokens": <int>, "outputTokens": <int> }`. |
+  | `model` | string \| null | The model that actually served the request. |
+
+The response JSON uses **camelCase** keys and `finishReason` is a string value such as `"Stop"`.
+
+### Example
+
+```java title="Application.java"
+Map<String, RevealPluginCallback> callbacks = new LinkedHashMap<>();
+
+callbacks.put("aiProvider:my-custom-provider", (userContext, message) -> {
+    // 'message' is a JSON ProviderRequest: { "prompt": "...", "intent": "default", "model": null }
+    // Call your LLM service here, then return a JSON ProviderResponse.
+    return CompletableFuture.completedFuture(
+            "{\"content\":\"Hello from my custom Java AI provider\","
+            + "\"finishReason\":\"Stop\","
+            + "\"usage\":{\"inputTokens\":1,\"outputTokens\":1},"
+            + "\"model\":\"my-custom-provider\"}");
+});
+
+RevealPlugin aiPlugin = RevealAIPlugin.withOptions(aiPluginOptions, callbacks);
+
+IRevealServer server = new RevealServerBuilder()
+        .addPlugin(aiPlugin)
+        // ...
+        .build();
+```
+
+To make your custom provider the default, set its key as the default provider:
+
+```java
+RevealAIPluginOptions aiPluginOptions = new RevealAIPluginOptions(
+        "my-custom-provider",   // defaultProvider
+        metadataCatalogPath,
+        null, null,
+        Map.of("settings", aiSettings));
+```
+
+:::tip Production callbacks
+
+Real callbacks should parse the incoming JSON (for example with Jackson) to read the `prompt`/`model`, call your LLM asynchronously, and serialize the response back. Returning `null` or an empty string causes the request to fail.
+
+:::
+
+## Node.js: Custom Providers via Callbacks
+
+Node.js uses the same callback-based mechanism as Java. You supply a callback (or a map of named callbacks) to the AI plugin options; each callback receives the request as a JSON string and returns the response as a JSON string.
+
+### Registration Conventions
+
+| Registration | Behavior |
+|--------------|----------|
+| A single `aiProvider` function | Registers one custom provider, selectable under the reserved name `Node`. |
+| A map of `{ "<key>": function }` | Registers **named** providers. Each `<key>` becomes a selectable provider/model name. |
+
+### Request and Response Contract
+
+The request and response payloads are identical to the [Java contract](#callback-signature):
+
+- **Input** - a JSON-serialized request: `{ "prompt": "...", "intent": "default", "model": null }`.
+- **Return value** - a JSON-serialized response with camelCase keys: `content`, `finishReason` (`Stop` \| `Length` \| `ContentFilter`), optional `usage` (`{ "inputTokens", "outputTokens" }`), and optional `model`.
+
+### Example
+
+```javascript title="index.js"
+const aiProviders = {
+    "my-custom-provider": async (userContext, message) => {
+        // 'message' is a JSON ProviderRequest.
+        // Call your LLM service here, then return a JSON ProviderResponse string.
+        return JSON.stringify({
+            content: "Hello from my custom Node.js AI provider",
+            finishReason: "Stop",
+            usage: { inputTokens: 1, outputTokens: 1 },
+            model: "my-custom-provider"
+        });
+    }
+};
+
+// Pass aiProviders when configuring the Reveal AI plugin options.
 ```

--- a/docs/ai/providers-custom-endpoints.md
+++ b/docs/ai/providers-custom-endpoints.md
@@ -182,4 +182,4 @@ When using custom endpoints, be aware of:
 
 ## Custom Providers
 
-If your endpoint doesn't follow the OpenAI-compatible API format, consider [building a custom provider](providers-building-custom.md) instead.
+If your endpoint doesn't follow the OpenAI-compatible API format, consider [building a custom provider](providers-building-custom.md) instead. Custom providers are available on ASP.NET Core (the `IAIProvider` interface), as well as Java and Node.js (via plugin callbacks).

--- a/docs/ai/providers-overview.md
+++ b/docs/ai/providers-overview.md
@@ -194,4 +194,4 @@ Map<String, Object> aiSettings = Map.of(
 
 ## Custom Providers
 
-If you need to integrate with an LLM service that isn't supported out of the box, you can [build a custom provider](providers-building-custom.md). Custom providers are currently supported on ASP.NET Core only.
+If you need to integrate with an LLM service that isn't supported out of the box, you can [build a custom provider](providers-building-custom.md). Custom providers are supported on **ASP.NET Core** (via the `IAIProvider` interface), **Java** (via a callback registered with the plugin), and **Node.js** (via a callback in the plugin options).

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ai/providers-building-custom.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ai/providers-building-custom.md
@@ -5,7 +5,19 @@ sidebar_label: カスタムプロバイダーの構築
 
 # カスタムプロバイダーの構築
 
-標準でサポートされていない LLM サービスと統合する必要がある場合、`IAIProvider` インターフェースを実装し、SDK に登録することでカスタムプロバイダーを作成できます。
+標準でサポートされていない LLM サービスと統合する必要がある場合、カスタムプロバイダーを作成し、SDK に登録することができます。
+
+:::info プラットフォームサポート
+
+アプローチはサーバープラットフォームによって異なります：
+
+- **ASP.NET Core** - `IAIProvider` インターフェースを実装し、`AddProvider` で登録します（以下で説明）。
+- **Java** - `RevealAIPlugin` にコールバックを登録します（[Java: コールバックによるカスタムプロバイダー](#java-コールバックによるカスタムプロバイダー)を参照）。
+- **Node.js** - AI プラグインオプションにコールバックを登録します（[Node.js: コールバックによるカスタムプロバイダー](#nodejs-コールバックによるカスタムプロバイダー)を参照）。
+
+対象サービスが OpenAI 互換の API を公開している場合は、任意のプラットフォームで OpenAI プロバイダーの[カスタムエンドポイント](providers-custom-endpoints.md)アプローチを使用することもできます。
+
+:::
 
 ## ステップ 1: プロバイダークラスの作成
 
@@ -106,7 +118,7 @@ builder.Services.AddRevealAI()
     });
 ```
 
-最初のパラメータは **プロバイダーキー** — プロバイダーを解決するために使用される一意の文字列識別子です。2番目のパラメータは、依存性注入用の `IServiceProvider` を受け取るファクトリ関数です。
+最初のパラメータは **プロバイダーキー** - プロバイダーを解決するために使用される一意の文字列識別子です。2番目のパラメータは、依存性注入用の `IServiceProvider` を受け取るファクトリ関数です。
 
 ## ステップ 3: デフォルトとして設定（オプション）
 
@@ -206,4 +218,129 @@ builder.Services.AddRevealAI()
     {
         return new MyCustomProvider(/* ... */);
     });
+```
+
+## Java: コールバックによるカスタムプロバイダー
+
+カスタムプロバイダーを実装するには、プロンプトリクエストを JSON として受け取り、レスポンスを JSON として返す**コールバック**を `RevealAIPlugin` に登録します。プラグインはコールバックを基盤となる AI エンジンにブリッジします。
+
+### 登録規則
+
+コールバックは、`RevealAIPlugin.withOptions(options, callbacks)` に渡す `Map<String, RevealPluginCallback>` のキーで登録されます：
+
+| キー | 動作 |
+|-----|----------|
+| `aiProvider` | 単一のカスタムプロバイダーを登録します。予約名 `CustomAIProvider` で選択可能になります。 |
+| `aiProvider:<key>` | **名前付き**プロバイダーを登録します。`<key>`（例: `my-custom-provider`）が選択可能なプロバイダー/モデル名になります。複数の名前付きプロバイダーを登録できます。 |
+
+:::warning 予約名
+
+`CustomAIProvider` は予約済みです。`aiProvider:CustomAIProvider` を渡すと `IllegalArgumentException` がスローされます。
+
+:::
+
+### コールバックシグネチャ
+
+プロバイダーコールバックは `RevealPluginCallback` を実装します：
+
+```java
+@FunctionalInterface
+public interface RevealPluginCallback {
+    CompletableFuture<String> invoke(IRVUserContext userContext, String message);
+}
+```
+
+- **`message`** - 以下のフィールドを含む JSON シリアライズされたリクエスト：
+
+  | フィールド | 型 | 説明 |
+  |-------|------|-------------|
+  | `prompt` | string | LLM に送信するプロンプト。 |
+  | `intent` | string | リクエストのインテント（例: `"default"`）。 |
+  | `model` | string \| null | オプションのモデルオーバーライド。`null` の場合、プロバイダーのデフォルトを使用します。 |
+
+- **戻り値** - 以下のフィールドを含む JSON シリアライズされたレスポンス：
+
+  | フィールド | 型 | 説明 |
+  |-------|------|-------------|
+  | `content` | string | 生成されたテキストコンテンツ。 |
+  | `finishReason` | string | 生成が停止した理由: `Stop`、`Length`、または `ContentFilter`。 |
+  | `usage` | object \| null | オプションのトークン使用量: `{ "inputTokens": <int>, "outputTokens": <int> }`。 |
+  | `model` | string \| null | リクエストを実際に処理したモデル。 |
+
+レスポンス JSON は **camelCase** キーを使用し、`finishReason` は `"Stop"` のような文字列値です。
+
+### 例
+
+```java title="Application.java"
+Map<String, RevealPluginCallback> callbacks = new LinkedHashMap<>();
+
+callbacks.put("aiProvider:my-custom-provider", (userContext, message) -> {
+    // 'message' は JSON ProviderRequest: { "prompt": "...", "intent": "default", "model": null }
+    // ここで LLM サービスを呼び出し、JSON ProviderResponse を返します。
+    return CompletableFuture.completedFuture(
+            "{\"content\":\"Hello from my custom Java AI provider\","
+            + "\"finishReason\":\"Stop\","
+            + "\"usage\":{\"inputTokens\":1,\"outputTokens\":1},"
+            + "\"model\":\"my-custom-provider\"}");
+});
+
+RevealPlugin aiPlugin = RevealAIPlugin.withOptions(aiPluginOptions, callbacks);
+
+IRevealServer server = new RevealServerBuilder()
+        .addPlugin(aiPlugin)
+        // ...
+        .build();
+```
+
+カスタムプロバイダーをデフォルトにするには、そのキーをデフォルトプロバイダーとして設定します：
+
+```java
+RevealAIPluginOptions aiPluginOptions = new RevealAIPluginOptions(
+        "my-custom-provider",   // defaultProvider
+        metadataCatalogPath,
+        null, null,
+        Map.of("settings", aiSettings));
+```
+
+:::tip 本番環境のコールバック
+
+実際のコールバックは、受信した JSON を解析し（例: Jackson を使用）、`prompt`/`model` を読み取り、LLM を非同期で呼び出し、レスポンスをシリアライズして返す必要があります。`null` または空文字列を返すとリクエストが失敗します。
+
+:::
+
+## Node.js: コールバックによるカスタムプロバイダー
+
+AI プラグインオプションにコールバック（または名前付きコールバックのマップ）を渡します。各コールバックはリクエストを JSON 文字列として受け取り、レスポンスを JSON 文字列として返します。
+
+### 登録規則
+
+| 登録方法 | 動作 |
+|--------------|----------|
+| 単一の `aiProvider` 関数 | 1 つのカスタムプロバイダーを登録します。予約名 `Node` で選択可能になります。 |
+| `{ "<key>": function }` のマップ | **名前付き**プロバイダーを登録します。各 `<key>` が選択可能なプロバイダー/モデル名になります。 |
+
+### リクエストとレスポンスの仕様
+
+リクエストとレスポンスのペイロードは [Java の仕様](#コールバックシグネチャ)と同一です：
+
+- **入力** - JSON シリアライズされたリクエスト: `{ "prompt": "...", "intent": "default", "model": null }`。
+- **戻り値** - camelCase キーを使用した JSON シリアライズされたレスポンス: `content`、`finishReason`（`Stop` \| `Length` \| `ContentFilter`）、オプションの `usage`（`{ "inputTokens", "outputTokens" }`）、オプションの `model`。
+
+### 例
+
+```javascript title="index.js"
+const aiProviders = {
+    "my-custom-provider": async (userContext, message) => {
+        // 'message' は JSON ProviderRequest。
+        // ここで LLM サービスを呼び出し、JSON ProviderResponse 文字列を返します。
+        return JSON.stringify({
+            content: "Hello from my custom Node.js AI provider",
+            finishReason: "Stop",
+            usage: { inputTokens: 1, outputTokens: 1 },
+            model: "my-custom-provider"
+        });
+    }
+};
+
+// Reveal AI プラグインオプションを設定する際に aiProviders を渡します。
 ```

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ai/providers-custom-endpoints.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ai/providers-custom-endpoints.md
@@ -77,4 +77,4 @@ builder.Services.AddRevealAI()
 
 ## カスタムプロバイダー
 
-エンドポイントが OpenAI 互換 API 形式に従っていない場合は、代わりに[カスタムプロバイダーの構築](providers-building-custom.md)を検討してください。
+エンドポイントが OpenAI 互換 API 形式に従っていない場合は、代わりに[カスタムプロバイダーの構築](providers-building-custom.md)を検討してください。カスタムプロバイダーは ASP.NET Core（`IAIProvider` インターフェース）、および Java と Node.js（プラグインコールバック経由）で利用できます。

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ai/providers-overview.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ai/providers-overview.md
@@ -86,4 +86,4 @@ builder.Services.AddRevealAI()
 
 ## カスタムプロバイダー
 
-標準でサポートされていない LLM サービスと統合する必要がある場合は、[カスタムプロバイダーを構築](providers-building-custom.md)できます。
+標準でサポートされていない LLM サービスと統合する必要がある場合は、[カスタムプロバイダーを構築](providers-building-custom.md)できます。カスタムプロバイダーは **ASP.NET Core**（`IAIProvider` インターフェース経由）、**Java**（プラグインに登録したコールバック経由）、および **Node.js**（プラグインオプションのコールバック経由）でサポートされています。


### PR DESCRIPTION
Update documentation for custom providers to include support for Java and Node.js