### PR TITLE
TokenUsage/StopReason and Datasources update

### DIFF
--- a/docs/ai/chat.md
+++ b/docs/ai/chat.md
@@ -84,9 +84,16 @@ When `stream` is `false` or omitted, the endpoint returns a plain JSON response:
 ```json
 {
   "explanation": "Based on your data, I've created a dashboard showing sales by region...",
-  "dashboard": "{...rdash JSON...}"
+  "dashboard": "{...rdash JSON...}",
+  "finishReason": "Stop",
+  "usage": {
+    "inputTokens": 1243,
+    "outputTokens": 287
+  }
 }
 ```
+
+`finishReason` is the stop reason reported by the LLM. `usage` contains token counts when the active provider reports them.
 
 On error, the response includes an error message with the appropriate HTTP status code (400 or 500):
 
@@ -133,7 +140,12 @@ data: {
   "message": "Chat processed successfully",
   "result": {
     "explanation": "Based on your data, I've created a dashboard showing sales by region...",
-    "dashboard": "{...rdash JSON...}"
+    "dashboard": "{...rdash JSON...}",
+    "finishReason": "Stop",
+    "usage": {
+      "inputTokens": 1243,
+      "outputTokens": 287
+    }
   }
 }
 ```
@@ -141,6 +153,10 @@ data: {
 **Result Structure:**
 - `explanation`: Natural language explanation of what was done
 - `dashboard`: Generated or modified dashboard JSON (when applicable)
+- `finishReason`: Why the LLM stopped generating content. Common values are `Stop`, `Length`, and `ContentFilter`
+- `usage`: Optional token usage details from the provider, typically including `inputTokens` and `outputTokens`
+
+The streamed `text` events only carry explanation fragments. `finishReason` and `usage` are returned in the final `complete` event payload.
 
 #### error Event
 Sent if processing fails.

--- a/docs/ai/guide-chat-interface.md
+++ b/docs/ai/guide-chat-interface.md
@@ -47,6 +47,9 @@ async function sendChatMessage(userInput: string) {
   messages.push({ role: 'assistant', content: currentMessage });
   renderMessages();
 
+  console.log('Stop reason:', result.finishReason);
+  console.log('Token usage:', result.usage);
+
   if (result.dashboard) {
     loadDashboard(result.dashboard);
   }
@@ -79,6 +82,8 @@ if (result.dashboard) {
   // Load the new or modified dashboard
   revealView.dashboard = await RVDashboard.loadFromJson(result.dashboard);
 }
+
+console.log(result.finishReason, result.usage);
 ```
 
 ### Editing Existing Dashboards

--- a/docs/ai/guide-insights-context-menus.md
+++ b/docs/ai/guide-insights-context-menus.md
@@ -89,7 +89,8 @@ function createInsightMenuItem(label, dashboard, insightType, visualizationId = 
       showError(error);
     });
 
-    await stream.finalResponse();
+    const result = await stream.finalResponse();
+    console.log(result.finishReason, result.usage);
     hideProgressIndicator();
   });
 }

--- a/docs/ai/guide-streaming-display.md
+++ b/docs/ai/guide-streaming-display.md
@@ -30,6 +30,8 @@ stream.on('text', (content) => {
 
 const result = await stream.finalResponse();
 console.log('Streaming complete:', result.explanation);
+console.log('Stop reason:', result.finishReason);
+console.log('Token usage:', result.usage);
 ```
 
 ## Combining with Progress Messages
@@ -57,7 +59,8 @@ stream.on('text', (content) => {
   output.scrollTop = output.scrollHeight; // Auto-scroll
 });
 
-await stream.finalResponse();
+const result = await stream.finalResponse();
+console.log(result.finishReason, result.usage);
 ```
 
 ## Tips

--- a/docs/ai/insights.md
+++ b/docs/ai/insights.md
@@ -71,9 +71,16 @@ When `stream` is `false` or omitted, the endpoint returns a plain JSON response:
 
 ```json
 {
-  "explanation": "Sales revenue reached $2.4M in Q4 2024, up 18% from Q3..."
+  "explanation": "Sales revenue reached $2.4M in Q4 2024, up 18% from Q3...",
+  "finishReason": "Stop",
+  "usage": {
+    "inputTokens": 842,
+    "outputTokens": 191
+  }
 }
 ```
+
+`finishReason` is the stop reason reported by the LLM. `usage` contains token counts when the active provider reports them.
 
 On error, the response includes an error message with the appropriate HTTP status code (400 or 500):
 
@@ -111,10 +118,22 @@ event: complete
 data: {
   "message": "Insights generated successfully",
   "result": {
-    "explanation": "Sales revenue reached $2.4M in Q4 2024, up 18% from Q3..."
+    "explanation": "Sales revenue reached $2.4M in Q4 2024, up 18% from Q3...",
+    "finishReason": "Stop",
+    "usage": {
+      "inputTokens": 842,
+      "outputTokens": 191
+    }
   }
 }
 ```
+
+**Result Structure:**
+- `explanation`: Complete natural language insight
+- `finishReason`: Why the LLM stopped generating content. Common values are `Stop`, `Length`, and `ContentFilter`
+- `usage`: Optional token usage details from the provider, typically including `inputTokens` and `outputTokens`
+
+The streamed `text` events only carry explanation fragments. `finishReason` and `usage` are returned in the final `complete` event payload.
 
 #### error Event
 Sent if insight generation fails.

--- a/docs/ai/metadata-catalog.md
+++ b/docs/ai/metadata-catalog.md
@@ -131,7 +131,9 @@ Common provider values:
 
 | Provider | Description |
 |----------|-------------|
+| `Cube` | Cube |
 | `SQLServer` | Microsoft SQL Server |
+| `SQLite` | SQLite |
 | `PostgreSQL` | PostgreSQL |
 | `MySQL` | MySQL |
 | `Oracle` | Oracle (Service Name) |
@@ -144,6 +146,8 @@ Common provider values:
 | `AmazonRedshift` | Amazon Redshift |
 | `MongoDB` | MongoDB |
 | `WebService` | Web Service / REST API / Excel files |
+
+Use the exact provider names shown above in your metadata catalog.
 
 ---
 

--- a/docs/ai/sdk-chat.md
+++ b/docs/ai/sdk-chat.md
@@ -23,6 +23,9 @@ const response = await client.ai.chat.sendMessage({
 console.log(response.explanation);
 // "I've analyzed your sales data for Q4 2024..."
 
+console.log(response.finishReason);
+console.log(response.usage?.inputTokens, response.usage?.outputTokens);
+
 if (response.dashboard) {
   // Load the generated dashboard
   loadDashboard(response.dashboard);
@@ -103,11 +106,18 @@ All parameters are passed in a single request object:
 ## Response Type
 
 ```typescript
+interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
 interface ChatResponse {
-  explanation?: string;   // AI-generated explanation
-  dashboard?: string;     // Generated/modified dashboard JSON
-  error?: string;         // Error message if request failed
+  explanation?: string;             // AI-generated explanation
+  dashboard?: string;               // Generated/modified dashboard JSON
+  finishReason?: string;            // Stop reason returned by the LLM
+  usage?: TokenUsage;               // Provider token usage, when available
+  error?: string;                   // Error message if request failed
 }
 ```
 
-The `explanation` field contains the AI's natural language response. The `dashboard` field is populated when dashboards are generated or modified.
+The `explanation` field contains the AI's natural language response. The `dashboard` field is populated when dashboards are generated or modified. `finishReason` reports why generation stopped, and `usage` exposes provider token counts when available.

--- a/docs/ai/sdk-insights.md
+++ b/docs/ai/sdk-insights.md
@@ -22,6 +22,9 @@ const insight = await client.ai.insights.get({
 
 console.log(insight.explanation);
 // "Sales revenue reached $2.4M in Q4 2024..."
+
+console.log(insight.finishReason);
+console.log(insight.usage?.inputTokens, insight.usage?.outputTokens);
 ```
 
 ## Insight Types
@@ -99,9 +102,16 @@ All parameters are passed in a single request object:
 ## Response Type
 
 ```typescript
+interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
 interface InsightResponse {
-  explanation: string;  // Complete AI-generated explanation
+  explanation: string;     // Complete AI-generated explanation
+  finishReason?: string;   // Stop reason returned by the LLM
+  usage?: TokenUsage;      // Provider token usage, when available
 }
 ```
 
-The `explanation` field contains the full insight text, whether you use non-streaming or streaming mode.
+The `explanation` field contains the full insight text, whether you use non-streaming or streaming mode. `finishReason` reports why generation stopped, and `usage` exposes provider token counts when available.

--- a/docs/ai/sdk-streaming.md
+++ b/docs/ai/sdk-streaming.md
@@ -52,6 +52,8 @@ stream.on('error', (error) => console.error('Error:', error));
 
 const result = await stream.finalResponse();
 console.log('Complete:', result.explanation);
+console.log('Stop reason:', result.finishReason);
+console.log('Token usage:', result.usage);
 ```
 
 ### Pattern 3: Aggregated Result from Stream
@@ -68,6 +70,7 @@ const stream = await client.ai.insights.get({
 // Wait for completion, returns InsightResponse
 const result = await stream.finalResponse();
 console.log(result.explanation);
+console.log(result.finishReason, result.usage);
 ```
 
 This is useful when you want the server-side benefits of streaming (e.g., timeout avoidance for long-running requests) without handling individual events.
@@ -84,6 +87,8 @@ When `stream: true`, the return type is `AIStream<T>` where `T` is the response 
 | `.on(event, handler)` | Register event-specific listeners |
 | `.finalResponse()` | Returns a promise that resolves with the complete response |
 | `.abort()` | Cancel the stream |
+
+The object returned by `.finalResponse()` is the same `ChatResponse` or `InsightResponse` you receive in non-streaming mode, including `finishReason` and optional `usage`.
 
 ## Stream Events
 


### PR DESCRIPTION
Updates examples and docs to show how to use/review the tokenUsage and stop reason for LLM calls. Adds Cube and SQLite as supported datasources.