### PR TITLE
Add AI "Choosing a Model" guide and correct unsupported multi-model docs

### DIFF
--- a/docs/ai/choosing-a-model.md
+++ b/docs/ai/choosing-a-model.md
@@ -1,0 +1,193 @@
+---
+sidebar_label: Choosing a Model
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Choosing a Model
+
+Reveal SDK AI works with any [supported provider](providers-overview.md) and the models each one offers. Your choice of model is the single biggest factor in the quality, speed, and cost of the AI features you expose to users. This page gives concrete recommendations — a flagship cloud model and a self-hosted local model — backed by Reveal's ongoing benchmarking.
+
+## What the model has to do
+
+Reveal asks the model to handle two very different kinds of work, and a model that excels at one is not guaranteed to excel at the other:
+
+- **Dashboard generation** — the [Chat](sdk-chat.md) endpoint turns a natural-language request ("show me sales by region for 2023") into a dashboard. This is the harder task: the model must emit strictly structured JSON that references real tables and fields, applies the correct chart types, and respects filters and rules. Small formatting mistakes cause the whole result to fail.
+- **Data insights** — the [Insights](sdk-insights.md) endpoint analyzes the data behind a visualization to produce summaries, statistical analysis (correlation, trend, mean/standard deviation), and forecasts. The output format is simpler, but the reasoning is more open-ended.
+
+## Recommended flagship model
+
+**Use GPT-4.1 (OpenAI).** It is the most balanced performer across both workloads — reliably handling dashboard generation while staying fast — and it is already the SDK's default model, so no extra configuration is required to adopt it.
+
+<Tabs groupId="code" queryString>
+  <TabItem value="aspnet" label="ASP.NET" default>
+
+```csharp title="Program.cs"
+builder.Services.AddRevealAI()
+    .AddOpenAI(options =>
+    {
+        options.ApiKey = builder.Configuration["RevealAI:OpenAI:ApiKey"];
+        options.Model = "gpt-4.1";
+    });
+```
+
+  </TabItem>
+
+  <TabItem value="node" label="Node.js">
+
+```javascript title="server.js"
+revealAI.withOptions({
+    defaultProvider: 'openai',
+    settings: {
+        openai: {
+            ApiKey: process.env.OPENAI_API_KEY,
+            Model: 'gpt-4.1'
+        }
+    }
+});
+```
+
+  </TabItem>
+
+  <TabItem value="java" label="Java">
+
+```java title="Application.java"
+Map<String, Object> aiSettings = Map.of(
+        "openai", Map.of(
+                "ApiKey", System.getenv("OPENAI_API_KEY"),
+                "Model", "gpt-4.1"));
+```
+
+  </TabItem>
+</Tabs>
+
+See the [OpenAI provider](providers-openai.md) for full configuration options.
+
+### Strong alternatives
+
+If you prefer a different provider, or want to compare quality and cost against your own workloads, these models also perform at or near flagship level:
+
+- **Claude Sonnet 4.5 / Claude Opus** ([Anthropic](providers-anthropic.md)) — match GPT-4.1 on quality, with Sonnet 4.5 offering a strong quality-to-cost balance. Expect somewhat higher latency on data insights.
+- **Gemini 2.5 Pro / Gemini 3 Pro** ([Google Gemini](providers-google-gemini.md)) — capable across both workloads and a good fit if you are already on Google Cloud.
+
+:::tip Reasoning models are not always better
+For these structured tasks, dedicated "reasoning" models tend to be **slower and less reliable** than GPT-4.1, not more capable — they take much longer to answer and are more prone to timeouts, especially on data insights. Reach for a fast, non-reasoning flagship model first.
+:::
+
+## Recommended local model
+
+If you need to keep data on your own infrastructure or avoid per-token API costs, you can run a model locally and point the OpenAI provider at it through a [custom endpoint](providers-custom-endpoints.md).
+
+**Use Gemma 4 26B (`gemma-4-26b-a4b-it`).** Among locally hosted models it delivers the best overall accuracy on both workloads, and it is small enough to run on a capable workstation (validated on a 64 GB Apple Silicon machine).
+
+If you want faster responses and a smaller memory footprint, **GPT-OSS 20B** is a strong runner-up — noticeably quicker, though a step behind Gemma 4 26B on data insights.
+
+Run either model with a server that exposes an OpenAI-compatible API — such as [Ollama](https://ollama.ai), [LM Studio](https://lmstudio.ai), or [vLLM](https://github.com/vllm-project/vllm) — and set the `Endpoint` and `Model` options:
+
+<Tabs groupId="code" queryString>
+  <TabItem value="aspnet" label="ASP.NET" default>
+
+```csharp title="Program.cs"
+builder.Services.AddRevealAI()
+    .AddOpenAI(options =>
+    {
+        options.ApiKey = "ollama";                        // local servers ignore the key
+        options.Endpoint = "http://localhost:11434/v1";
+        options.Model = "gemma-4-26b-a4b-it";
+    });
+```
+
+  </TabItem>
+
+  <TabItem value="node" label="Node.js">
+
+```javascript title="server.js"
+revealAI.withOptions({
+    defaultProvider: 'openai',
+    settings: {
+        openai: {
+            ApiKey: 'ollama',                             // local servers ignore the key
+            Endpoint: 'http://localhost:11434/v1',
+            Model: 'gemma-4-26b-a4b-it'
+        }
+    }
+});
+```
+
+  </TabItem>
+
+  <TabItem value="java" label="Java">
+
+```java title="Application.java"
+Map<String, Object> aiSettings = Map.of(
+        "openai", Map.of(
+                "ApiKey", "ollama",                       // local servers ignore the key
+                "Endpoint", "http://localhost:11434/v1",
+                "Model", "gemma-4-26b-a4b-it"));
+```
+
+  </TabItem>
+</Tabs>
+
+:::note Local models and dashboard generation
+Local models are a good fit for data insights and for straightforward dashboard generation. For complex, multi-widget dashboards, the strongest cloud models are still meaningfully more reliable — validate against your own prompts before committing to a fully local setup. Avoid "thinking"/reasoning local models: they struggle to stay within the required JSON schema and are slow on modest hardware.
+:::
+
+## Benchmark summary
+
+The recommendations above come from Reveal's ongoing benchmarking. Each model runs two 10-task suites built on the Northwind sample database — one for dashboard generation, one for data insights — with tasks of increasing difficulty graded by an independent LLM judge. The score is how many of the 10 tasks the model handled **reliably** (a correct result on the majority of attempts), out of 10. **DNF** means the suite did not complete — the model failed the early tasks and the run was stopped.
+
+The full results for every model tested are below. Find your current model to see how it compares — if it scores poorly on the workload you care about, the models recommended above are drop-in replacements.
+
+### Cloud models
+
+| Model | Provider | Dashboard generation | Data insights |
+|-------|----------|:--------------------:|:-------------:|
+| **GPT-4.1** *(recommended)* | OpenAI | 10 | 9 |
+| GPT-5.4 | OpenAI | 6 | 10 |
+| GPT-5.4 mini | OpenAI | 6 | 9 |
+| GPT-5.4 nano | OpenAI | 6 | 6 |
+| GPT-5.3 Codex | OpenAI | 7 | 9 |
+| GPT-5.2 | OpenAI | 8 | 9 |
+| GPT-5.1 | OpenAI | 8 | 8 |
+| GPT-5 | OpenAI | 6 | 6 |
+| Claude Opus 4.6 | Anthropic | 9 | 10 |
+| Claude Opus 4.5 | Anthropic | 8 | 8 |
+| Claude Opus 4.1 | Anthropic | 10 | 4 |
+| Claude Sonnet 4.6 | Anthropic | 6 | 10 |
+| Claude Sonnet 4.5 | Anthropic | 9 | 9 |
+| Gemini 3.1 Pro | Google | 8 | 9 |
+| Gemini 3 Pro | Google | 7 | 9 |
+| Gemini 3 Flash | Google | 6 | 7 |
+| Gemini 3.1 Flash Lite | Google | 4 | 7 |
+| Gemini 2.5 Pro | Google | 6 | 8 |
+| Gemini 2.5 Flash | Google | 5 | 6 |
+| Mercury 2 | Inception Labs | 4 | 5 |
+
+Newer and preview model versions were sometimes captured under early-access conditions and their scores may not reflect current generally-available behavior. Latency varies widely too: reasoning-oriented models (several of the GPT-5.x variants, and Claude Opus/Sonnet when thinking is engaged) answer much more slowly — especially on data insights — without a matching gain in reliability.
+
+### Open-weight models
+
+These models can be self-hosted or accessed through a hosted-inference provider, using the [custom endpoint](providers-custom-endpoints.md) configuration.
+
+| Model | Dashboard generation | Data insights | Notes |
+|-------|:--------------------:|:-------------:|-------|
+| **Gemma 4 26B** *(recommended)* | 7 | 8 | Best open-weight accuracy overall |
+| GPT-OSS 20B | 6 | 6 | Fastest; light memory footprint |
+| GPT-OSS 120B | 5 | 8 | Larger; strong on data insights |
+| Kimi K2 Instruct | 1 | 9 | Excellent insights, weak generation |
+| Qwen3 32B | 6 | 2 | Decent generation, weak insights |
+| Llama 4 Maverick 17B | 3 | 6 | |
+| Llama 3.3 70B | 1 | 6 | |
+| Gemma 3 12B | 2 | 4 | Smallest; limited on harder tasks |
+| Qwen3.5 35B-A3B | 3 | DNF | Insights suite did not complete |
+| Nemotron 3 Nano 30B | 0 | 3 | Reasoning model; poor schema adherence |
+| Gemma 3 27B | DNF | — | Generation suite did not complete |
+| Llama 3 70B | DNF | — | Generation suite did not complete |
+
+Open-weight scores depend heavily on quantization, host, and sampling settings — treat them as indicative of a well-configured run rather than fixed numbers. The results above use 4-bit to 8-bit quantizations on workstation-class hardware or a hosted-inference provider.
+
+:::info A moving target
+Model quality shifts every time a provider ships a new version, so treat these figures as a snapshot rather than a permanent ranking. The best way to choose is to test the top candidates against your own data and prompts before you commit.
+:::

--- a/docs/ai/providers-overview.md
+++ b/docs/ai/providers-overview.md
@@ -22,22 +22,18 @@ For ASP.NET Core, each provider is a separate NuGet package — install only the
 
 ## How Providers Work
 
-All providers implement a common provider interface and are registered with the AI runtime. The SDK supports registering multiple providers simultaneously and resolves the appropriate one based on the request or a configured default.
+All providers implement a common provider interface and are registered with the AI runtime. You configure a single provider, and the AI runtime uses it for all requests.
 
 ### Registering Providers
 
 <Tabs groupId="code" queryString>
   <TabItem value="aspnet" label="ASP.NET" default>
 
-Chain extension methods after `AddRevealAI()`:
+Register a provider after `AddRevealAI()`:
 
 ```csharp
 builder.Services.AddRevealAI()
     .AddOpenAI(options =>
-    {
-        options.ApiKey = "your-api-key";
-    })
-    .AddAnthropic(options =>
     {
         options.ApiKey = "your-api-key";
     });
@@ -47,14 +43,13 @@ builder.Services.AddRevealAI()
 
   <TabItem value="node" label="Node.js">
 
-Pass each provider's settings under its lowercase key in the `settings` object:
+Pass the provider's settings under its lowercase key in the `settings` object:
 
 ```javascript
 revealAI.withOptions({
     defaultProvider: 'openai',
     settings: {
-        openai:    { ApiKey: 'your-api-key' },
-        anthropic: { ApiKey: 'your-api-key' }
+        openai: { ApiKey: 'your-api-key' }
     }
 });
 ```
@@ -63,12 +58,11 @@ revealAI.withOptions({
 
   <TabItem value="java" label="Java">
 
-Pass each provider's settings under its lowercase key in the `settings` map:
+Pass the provider's settings under its lowercase key in the `settings` map:
 
 ```java
 Map<String, Object> aiSettings = Map.of(
-        "openai",    Map.of("ApiKey", "your-api-key"),
-        "anthropic", Map.of("ApiKey", "your-api-key"));
+        "openai", Map.of("ApiKey", "your-api-key"));
 
 RevealAIPluginOptions aiPluginOptions = new RevealAIPluginOptions(
         "openai",
@@ -83,7 +77,7 @@ RevealAIPluginOptions aiPluginOptions = new RevealAIPluginOptions(
 
 ### Default Provider
 
-The SDK uses a default provider when no specific provider is requested. Available provider keys: `openai`, `azure-openai`, `anthropic`, `google`.
+The `DefaultProvider` setting tells the SDK which provider to use. Available provider keys: `openai`, `azure-openai`, `anthropic`, `google`.
 
 <Tabs groupId="code" queryString>
   <TabItem value="aspnet" label="ASP.NET" default>
@@ -126,7 +120,7 @@ new RevealAIPluginOptions(
 
 ### Configuration Binding
 
-For ASP.NET Core, all providers support configuration binding from `appsettings.json` under the `RevealAI` section. Options set in code take precedence over configuration file values:
+For ASP.NET Core, the provider supports configuration binding from `appsettings.json` under the `RevealAI` section. Options set in code take precedence over configuration file values:
 
 ```json title="appsettings.json"
 {
@@ -135,62 +129,12 @@ For ASP.NET Core, all providers support configuration binding from `appsettings.
     "OpenAI": {
       "ApiKey": "sk-...",
       "Model": "gpt-4.1"
-    },
-    "Anthropic": {
-      "ApiKey": "sk-ant-..."
     }
   }
 }
 ```
 
 For Node.js and Java, load your settings from environment variables, a secrets manager, or a local config file and pass them inline at startup.
-
-### Multiple Providers
-
-You can register multiple providers and the SDK will resolve the appropriate one based on the request. This is useful for scenarios such as:
-
-- Using different models for different types of analysis
-- Providing fallback options
-- Cost optimization by routing simpler tasks to less expensive models
-
-<Tabs groupId="code" queryString>
-  <TabItem value="aspnet" label="ASP.NET" default>
-
-```csharp
-builder.Services.AddRevealAI()
-    .AddOpenAI()        // Registered as "openai"
-    .AddAnthropic()     // Registered as "anthropic"
-    .AddGoogle();       // Registered as "google"
-```
-
-  </TabItem>
-
-  <TabItem value="node" label="Node.js">
-
-```javascript
-revealAI.withOptions({
-    defaultProvider: 'openai',
-    settings: {
-        openai:    { ApiKey: process.env.OPENAI_API_KEY },
-        anthropic: { ApiKey: process.env.ANTHROPIC_API_KEY },
-        google:    { ProjectId: process.env.GCP_PROJECT_ID }
-    }
-});
-```
-
-  </TabItem>
-
-  <TabItem value="java" label="Java">
-
-```java
-Map<String, Object> aiSettings = Map.of(
-        "openai",    Map.of("ApiKey", System.getenv("OPENAI_API_KEY")),
-        "anthropic", Map.of("ApiKey", System.getenv("ANTHROPIC_API_KEY")),
-        "google",    Map.of("ProjectId", System.getenv("GCP_PROJECT_ID")));
-```
-
-  </TabItem>
-</Tabs>
 
 ## Custom Providers
 

--- a/docs/ai/sdk-chat.md
+++ b/docs/ai/sdk-chat.md
@@ -99,7 +99,6 @@ All parameters are passed in a single request object:
 | `visualizationId` | `string` | No | Visualization ID for visualization-specific context |
 | `intent` | `string` | No | Intent for freeform LLM queries |
 | `updateChatState` | `boolean` | No | Whether to update the chat state after this query |
-| `model` | `string` | No | Name of specific LLM model to use |
 | `signal` | `AbortSignal` | No | AbortSignal for cancelling the request |
 | `stream` | `boolean` | No | Enable streaming mode (default: `false`) |
 

--- a/docs/ai/sdk-insights.md
+++ b/docs/ai/sdk-insights.md
@@ -93,7 +93,6 @@ All parameters are passed in a single request object:
 | `visualizationId` | `string` | No | Visualization ID to analyze |
 | `type` | `InsightType` | Yes | Type: `'summary'`, `'analysis'`, `'forecast'` |
 | `forecastPeriods` | `number` | No | Periods to forecast (default: 6) |
-| `model` | `string` | No | Name of specific LLM model to use |
 | `signal` | `AbortSignal` | No | AbortSignal for cancelling the request |
 | `stream` | `boolean` | No | Enable streaming mode (default: `false`) |
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ai/choosing-a-model.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ai/choosing-a-model.md
@@ -1,0 +1,193 @@
+---
+sidebar_label: モデルの選択
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# モデルの選択
+
+Reveal SDK AI は、[サポートされているプロバイダー](providers-overview.md)とそれぞれが提供するモデルで動作します。モデルの選択は、ユーザーに提供する AI 機能の品質、速度、コストを左右する最も大きな要因です。このページでは、Reveal が継続的に実施しているベンチマークに基づいて、フラッグシップのクラウドモデルとセルフホスト型のローカルモデルという具体的な推奨事項を示します。
+
+## モデルに求められる処理
+
+Reveal はモデルに対して、性質が大きく異なる 2 種類の処理を求めます。一方が得意なモデルが、もう一方も得意であるとは限りません。
+
+- **ダッシュボード生成** — [Chat](sdk-chat.md) エンドポイントは、自然言語のリクエスト（「2023 年の地域別売上を見せて」など）をダッシュボードに変換します。これはより難しいタスクです。モデルは、実在するテーブルやフィールドを参照し、適切なチャートタイプを適用し、フィルターやルールを守った、厳密に構造化された JSON を出力する必要があります。わずかな書式の誤りでも結果全体が失敗します。
+- **データインサイト** — [Insights](sdk-insights.md) エンドポイントは、ビジュアライゼーションの背後にあるデータを分析し、要約、統計分析（相関、傾向、平均・標準偏差）、予測を生成します。出力形式はより単純ですが、推論はより自由度が高くなります。
+
+## 推奨フラッグシップモデル
+
+**GPT-4.1（OpenAI）を使用してください。** 両方のワークロードで最もバランスの取れた性能を発揮し、ダッシュボード生成を確実に処理しながら高速性を維持します。さらに、これは SDK のデフォルトモデルでもあるため、採用にあたって追加の設定は必要ありません。
+
+<Tabs groupId="code" queryString>
+  <TabItem value="aspnet" label="ASP.NET" default>
+
+```csharp title="Program.cs"
+builder.Services.AddRevealAI()
+    .AddOpenAI(options =>
+    {
+        options.ApiKey = builder.Configuration["RevealAI:OpenAI:ApiKey"];
+        options.Model = "gpt-4.1";
+    });
+```
+
+  </TabItem>
+
+  <TabItem value="node" label="Node.js">
+
+```javascript title="server.js"
+revealAI.withOptions({
+    defaultProvider: 'openai',
+    settings: {
+        openai: {
+            ApiKey: process.env.OPENAI_API_KEY,
+            Model: 'gpt-4.1'
+        }
+    }
+});
+```
+
+  </TabItem>
+
+  <TabItem value="java" label="Java">
+
+```java title="Application.java"
+Map<String, Object> aiSettings = Map.of(
+        "openai", Map.of(
+                "ApiKey", System.getenv("OPENAI_API_KEY"),
+                "Model", "gpt-4.1"));
+```
+
+  </TabItem>
+</Tabs>
+
+設定オプションの詳細については、[OpenAI プロバイダー](providers-openai.md)を参照してください。
+
+### 有力な代替モデル
+
+別のプロバイダーを希望する場合や、独自のワークロードで品質とコストを比較したい場合は、次のモデルもフラッグシップと同等かそれに近い性能を発揮します。
+
+- **Claude Sonnet 4.5 / Claude Opus**（[Anthropic](providers-anthropic.md)）— 品質面で GPT-4.1 に匹敵します。特に Sonnet 4.5 は品質とコストのバランスに優れています。データインサイトでは、レイテンシーがやや高くなる傾向があります。
+- **Gemini 2.5 Pro / Gemini 3 Pro**（[Google Gemini](providers-google-gemini.md)）— 両方のワークロードに対応でき、すでに Google Cloud を利用している場合に適しています。
+
+:::tip 推論モデルが常に優れているとは限りません
+これらの構造化されたタスクにおいて、専用の「推論」モデルは GPT-4.1 よりも**低速で信頼性が低い**傾向があり、必ずしも高性能ではありません。回答までに非常に長い時間がかかり、特にデータインサイトではタイムアウトが発生しやすくなります。まずは高速な非推論のフラッグシップモデルを検討してください。
+:::
+
+## 推奨ローカルモデル
+
+データを自社のインフラ内に保持する必要がある場合や、トークン単位の API コストを回避したい場合は、モデルをローカルで実行し、[カスタムエンドポイント](providers-custom-endpoints.md)を通じて OpenAI プロバイダーをそこに向けることができます。
+
+**Gemma 4 26B（`gemma-4-26b-a4b-it`）を使用してください。** ローカルホスト型モデルの中で、両方のワークロードにわたって総合的に最も高い精度を発揮し、高性能なワークステーションで実行できる程度に小型です（64 GB の Apple Silicon マシンで検証済み）。
+
+より高速な応答とより少ないメモリ使用量を求める場合は、**GPT-OSS 20B** が有力な次点です。明らかに高速ですが、データインサイトでは Gemma 4 26B に一歩及びません。
+
+いずれのモデルも、[Ollama](https://ollama.ai)、[LM Studio](https://lmstudio.ai)、[vLLM](https://github.com/vllm-project/vllm) など、OpenAI 互換 API を公開するサーバーで実行し、`Endpoint` と `Model` オプションを設定してください。
+
+<Tabs groupId="code" queryString>
+  <TabItem value="aspnet" label="ASP.NET" default>
+
+```csharp title="Program.cs"
+builder.Services.AddRevealAI()
+    .AddOpenAI(options =>
+    {
+        options.ApiKey = "ollama";                        // ローカルサーバーはキーを無視します
+        options.Endpoint = "http://localhost:11434/v1";
+        options.Model = "gemma-4-26b-a4b-it";
+    });
+```
+
+  </TabItem>
+
+  <TabItem value="node" label="Node.js">
+
+```javascript title="server.js"
+revealAI.withOptions({
+    defaultProvider: 'openai',
+    settings: {
+        openai: {
+            ApiKey: 'ollama',                             // ローカルサーバーはキーを無視します
+            Endpoint: 'http://localhost:11434/v1',
+            Model: 'gemma-4-26b-a4b-it'
+        }
+    }
+});
+```
+
+  </TabItem>
+
+  <TabItem value="java" label="Java">
+
+```java title="Application.java"
+Map<String, Object> aiSettings = Map.of(
+        "openai", Map.of(
+                "ApiKey", "ollama",                       // ローカルサーバーはキーを無視します
+                "Endpoint", "http://localhost:11434/v1",
+                "Model", "gemma-4-26b-a4b-it"));
+```
+
+  </TabItem>
+</Tabs>
+
+:::note ローカルモデルとダッシュボード生成
+ローカルモデルは、データインサイトや単純なダッシュボード生成には適しています。ただし、複雑な複数ウィジェットのダッシュボードについては、最も高性能なクラウドモデルの方が依然として明らかに信頼性が高いため、完全なローカル構成に踏み切る前に独自のプロンプトで検証してください。「思考型」／推論型のローカルモデルは避けてください。必要な JSON スキーマを守るのが苦手で、控えめなハードウェアでは低速です。
+:::
+
+## ベンチマークの概要
+
+上記の推奨事項は、Reveal が継続的に実施しているベンチマークに基づいています。各モデルは、Northwind サンプルデータベースを用いた 2 つの 10 タスクのスイート（1 つはダッシュボード生成用、もう 1 つはデータインサイト用）を実行します。タスクは難易度が段階的に上がり、独立した LLM ジャッジによって採点されます。スコアは、モデルが 10 タスクのうちいくつを**確実に**処理できたか（大半の試行で正しい結果を返したか）を 10 点満点で示したものです。**DNF** はスイートが完走しなかったこと（モデルが序盤のタスクで失敗し、実行が中止されたこと）を意味します。
+
+テストしたすべてのモデルの全結果を以下に示します。現在お使いのモデルを見つけて、比較してみてください。重視するワークロードでスコアが低い場合、上記で推奨したモデルはそのまま置き換えられます。
+
+### クラウドモデル
+
+| モデル | プロバイダー | ダッシュボード生成 | データインサイト |
+|-------|----------|:--------------------:|:-------------:|
+| **GPT-4.1**（推奨） | OpenAI | 10 | 9 |
+| GPT-5.4 | OpenAI | 6 | 10 |
+| GPT-5.4 mini | OpenAI | 6 | 9 |
+| GPT-5.4 nano | OpenAI | 6 | 6 |
+| GPT-5.3 Codex | OpenAI | 7 | 9 |
+| GPT-5.2 | OpenAI | 8 | 9 |
+| GPT-5.1 | OpenAI | 8 | 8 |
+| GPT-5 | OpenAI | 6 | 6 |
+| Claude Opus 4.6 | Anthropic | 9 | 10 |
+| Claude Opus 4.5 | Anthropic | 8 | 8 |
+| Claude Opus 4.1 | Anthropic | 10 | 4 |
+| Claude Sonnet 4.6 | Anthropic | 6 | 10 |
+| Claude Sonnet 4.5 | Anthropic | 9 | 9 |
+| Gemini 3.1 Pro | Google | 8 | 9 |
+| Gemini 3 Pro | Google | 7 | 9 |
+| Gemini 3 Flash | Google | 6 | 7 |
+| Gemini 3.1 Flash Lite | Google | 4 | 7 |
+| Gemini 2.5 Pro | Google | 6 | 8 |
+| Gemini 2.5 Flash | Google | 5 | 6 |
+| Mercury 2 | Inception Labs | 4 | 5 |
+
+新しいバージョンやプレビュー版のモデルは、早期アクセスの条件下で測定された場合があり、そのスコアは現在の一般提供（GA）版の挙動を反映していない可能性があります。レイテンシーも大きく異なります。推論志向のモデル（GPT-5.x の一部や、思考が有効なときの Claude Opus / Sonnet）は、特にデータインサイトで回答が大幅に遅くなりますが、それに見合った信頼性の向上はありません。
+
+### オープンウェイトモデル
+
+これらのモデルは、[カスタムエンドポイント](providers-custom-endpoints.md)の設定を使用して、セルフホストするか、ホスト型推論プロバイダー経由でアクセスできます。
+
+| モデル | ダッシュボード生成 | データインサイト | メモ |
+|-------|:--------------------:|:-------------:|-------|
+| **Gemma 4 26B**（推奨） | 7 | 8 | オープンウェイトで総合的に最高精度 |
+| GPT-OSS 20B | 6 | 6 | 最速。メモリ使用量が少ない |
+| GPT-OSS 120B | 5 | 8 | 大型。データインサイトに強い |
+| Kimi K2 Instruct | 1 | 9 | インサイトに優れるが生成は弱い |
+| Qwen3 32B | 6 | 2 | 生成はまずまず、インサイトは弱い |
+| Llama 4 Maverick 17B | 3 | 6 | |
+| Llama 3.3 70B | 1 | 6 | |
+| Gemma 3 12B | 2 | 4 | 最小。難しいタスクには不向き |
+| Qwen3.5 35B-A3B | 3 | DNF | インサイトスイートが完走せず |
+| Nemotron 3 Nano 30B | 0 | 3 | 推論モデル。スキーマ遵守が不十分 |
+| Gemma 3 27B | DNF | — | 生成スイートが完走せず |
+| Llama 3 70B | DNF | — | 生成スイートが完走せず |
+
+オープンウェイトモデルのスコアは、量子化、ホスト、サンプリング設定に大きく左右されます。固定的な数値ではなく、適切に構成された実行における目安として扱ってください。上記の結果は、ワークステーションクラスのハードウェアまたはホスト型推論プロバイダー上で、4 ビット〜8 ビットの量子化を使用したものです。
+
+:::info 状況は常に変化します
+モデルの品質は、プロバイダーが新しいバージョンをリリースするたびに変化します。そのため、これらの数値は恒久的なランキングではなく、あくまで一時点のスナップショットとして扱ってください。最適な選択方法は、決定する前に上位の候補を独自のデータとプロンプトで検証することです。
+:::

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ai/providers-overview.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ai/providers-overview.md
@@ -18,19 +18,15 @@ Reveal SDK AI は、さまざまな大規模言語モデル（LLM）サービス
 
 ## プロバイダーの仕組み
 
-すべてのプロバイダーは `IAIProvider` インターフェースを実装し、`IRevealAIBuilder` のフルーエント API を通じて登録されます。SDK はキー付きサービスを使用した依存性注入を採用しており、複数のプロバイダーを同時に登録できます。
+すべてのプロバイダーは `IAIProvider` インターフェースを実装し、`IRevealAIBuilder` のフルーエント API を通じて登録されます。1 つのプロバイダーを設定すると、AI ランタイムはすべてのリクエストでそれを使用します。
 
 ### プロバイダーの登録
 
-プロバイダーは `AddRevealAI()` の後に拡張メソッドをチェーンして追加します：
+プロバイダーは `AddRevealAI()` の後に拡張メソッドを追加して登録します：
 
 ```csharp
 builder.Services.AddRevealAI()
     .AddOpenAI(options =>
-    {
-        options.ApiKey = "your-api-key";
-    })
-    .AddAnthropic(options =>
     {
         options.ApiKey = "your-api-key";
     });
@@ -38,7 +34,7 @@ builder.Services.AddRevealAI()
 
 ### デフォルトプロバイダー
 
-特定のプロバイダーが指定されていない場合、SDK はデフォルトプロバイダーを使用します。`appsettings.json` で設定できます：
+`DefaultProvider` 設定で、SDK が使用するプロバイダーを指定します。`appsettings.json` で設定できます：
 
 ```json title="appsettings.json"
 {
@@ -52,7 +48,7 @@ builder.Services.AddRevealAI()
 
 ### 設定のバインディング
 
-すべてのプロバイダーは `appsettings.json` の `RevealAI` セクションからの設定バインディングをサポートしています。コードで設定したオプションは設定ファイルの値よりも優先されます：
+プロバイダーは `appsettings.json` の `RevealAI` セクションからの設定バインディングをサポートしています。コードで設定したオプションは設定ファイルの値よりも優先されます：
 
 ```json title="appsettings.json"
 {
@@ -61,27 +57,9 @@ builder.Services.AddRevealAI()
     "OpenAI": {
       "ApiKey": "sk-...",
       "Model": "gpt-4.1"
-    },
-    "Anthropic": {
-      "ApiKey": "sk-ant-..."
     }
   }
 }
-```
-
-### 複数プロバイダーの使用
-
-複数のプロバイダーを登録でき、SDK はリクエストに基づいて適切なプロバイダーを解決します。以下のようなシナリオで便利です：
-
-- 異なる種類の分析に異なるモデルを使用する
-- フォールバックオプションを提供する
-- 簡単なタスクをより安価なモデルにルーティングしてコストを最適化する
-
-```csharp
-builder.Services.AddRevealAI()
-    .AddOpenAI()        // "openai" として登録
-    .AddAnthropic()     // "anthropic" として登録
-    .AddGoogle();       // "google" として登録
 ```
 
 ## カスタムプロバイダー

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ai/sdk-chat.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ai/sdk-chat.md
@@ -96,7 +96,6 @@ console.log(response.explanation);
 | `visualizationId` | `string` | いいえ | ビジュアライゼーション固有のコンテキスト用のビジュアライゼーション ID |
 | `intent` | `string` | いいえ | 自由形式の LLM クエリ用のインテント |
 | `updateChatState` | `boolean` | いいえ | このクエリの後にチャットの状態を更新するかどうか |
-| `model` | `string` | いいえ | 使用する特定の LLM モデルの名前 |
 | `signal` | `AbortSignal` | いいえ | リクエストをキャンセルするための AbortSignal |
 | `stream` | `boolean` | いいえ | ストリーミングモードを有効にする（デフォルト: `false`） |
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ai/sdk-insights.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ai/sdk-insights.md
@@ -90,7 +90,6 @@ const insight = await client.ai.insights.get({
 | `visualizationId` | `string` | いいえ | 分析対象のビジュアライゼーション ID |
 | `type` | `InsightType` | はい | タイプ: `'summary'`、`'analysis'`、`'forecast'` |
 | `forecastPeriods` | `number` | いいえ | 予測する期間数（デフォルト: 6） |
-| `model` | `string` | いいえ | 使用する特定の LLM モデルの名前 |
 | `signal` | `AbortSignal` | いいえ | リクエストをキャンセルするための AbortSignal |
 | `stream` | `boolean` | いいえ | ストリーミングモードを有効にする（デフォルト: `false`） |
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -269,6 +269,7 @@ const sidebars: SidebarsConfig = {
     {
       type: "category", label: "Providers", collapsed: false, collapsible: false, className: "sidebar__header", items: [
         { type: "doc", label: "Overview", key: "ai-providers-overview", id: "ai/providers-overview" },
+        { type: "doc", label: "Choosing a Model", id: "ai/choosing-a-model" },
         { type: "doc", label: "OpenAI", id: "ai/providers-openai" },
         { type: "doc", label: "Azure OpenAI", id: "ai/providers-azure-openai" },
         { type: "doc", label: "Anthropic", id: "ai/providers-anthropic" },


### PR DESCRIPTION
## What this does

Adds a new **Choosing a Model** topic under **AI → Providers**, distilled from Reveal's internal LLM benchmarking wiki into public-safe guidance, and corrects existing AI docs that claimed capabilities the SDK doesn't yet support.

### New page — `docs/ai/choosing-a-model.md` (+ Japanese)
- **Recommended flagship model: GPT-4.1** — most balanced across both workloads and already the SDK default.
- **Recommended local model: Gemma 4 26B** — best open-weight accuracy; GPT-OSS 20B noted as the faster, lighter runner-up.
- **Full benchmark comparison** of every model tested (20 cloud + 12 open-weight), so customers can locate their current model and see how it compares. Scores are the reliability metric (tasks handled correctly on the majority of attempts, out of 10) across two workloads: dashboard generation (Chat) and data insights (Insights).
- Added to the `Providers` sidebar group, right after *Overview*.

### Corrections to existing docs
The SDK does **not** currently support using multiple models/providers at the same time, so:
- `providers-overview.md` — removed the **Multiple Providers** section and trimmed the registration/config-binding examples to a single provider; reworded the "registers multiple simultaneously / resolves per request" claim.
- `sdk-chat.md` and `sdk-insights.md` — removed the per-request **`model`** request parameter from the parameter tables (to be restored when that support ships).

## Why
The source material is an internal, infrastructure-specific research doc. This turns the useful parts (model guidance + a comparison customers can self-locate in) into public docs, while stripping internal details (API keys, hardware, raw result files, the judge prompt) and removing forward-looking capability claims that aren't live yet.

## Verification
`npm run build` passes clean for both `en` and `ja` — no broken links or anchors.

## Notes for reviewers
- **Public competitor leaderboard:** the benchmark tables name competitor models (OpenAI/Anthropic/Google), some scoring at or above GPT-4.1 on a dimension. Intentional (it's what makes "compare your model" useful), but worth a marketing/legal skim.
- **Preview/early-access versions** appear in the tables; their numbers may not reflect current GA behavior. There's a caveat under the cloud table.
- **Flagship pick is a close call** between GPT-4.1 and Claude Opus — I led with GPT-4.1 since it's the SDK default; easy to change.
- **Versioned docs not touched:** the same old multi-provider claim still exists in `versioned_docs/version-1.8.4/…` and its Japanese mirror. I left the frozen 1.8.4 snapshot alone — say the word if you want it corrected too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)