### PR TITLE
Use the Reveal AI plugin instead of Inkeep

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          PLUGIN_PAT: ${{ secrets.PLUGIN_PAT }}
 
       - name: Build documentation
         run: npm run build

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+@IgniteUI:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${PLUGIN_PAT}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,8 @@ steps:
 - script: |
     npm install
   displayName: Npm Install
+  env:
+    PLUGIN_PAT: $(PLUGIN_PAT)
 
 - script: |
     npm run build

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -46,6 +46,7 @@ const config: Config = {
   plugins: [
     ["docusaurus-node-polyfills", { onlyAliases: ["process"] }],
     ["@docusaurus/plugin-google-tag-manager", { containerId: "GTM-WXWCMQZ" }],
+    ["@igniteui/reveal-ai-plugin", { stage: "dev" }],
   ],
 
   i18n: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@docusaurus/preset-classic": "^3.10.1",
         "@docusaurus/remark-plugin-npm2yarn": "^3.10.1",
         "@docusaurus/theme-mermaid": "^3.10.1",
+        "@igniteui/reveal-ai-plugin": "^1.0.0",
         "@mdx-js/react": "^3.0.0",
         "@monaco-editor/react": "^4.4.6",
         "clsx": "^2.1.0",
@@ -47,36 +48,95 @@
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.8.tgz",
-      "integrity": "sha512-3YEorYg44niXcm7gkft3nXYItHd44e8tmh4D33CTszPgP0QWkaLEaFywiNyJBo7UL/mqObA/G9RYuU7R8tN1IA==",
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.9.tgz",
+      "integrity": "sha512-4U2JKLMWlDu0CotYyUkWakDxr8AIav3QtIUXXRpfavYN29aVWfzlwJp9T0rPKEf/dO2QCPAUc0Kq1Tj1GJxo2A==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.19.8",
-        "@algolia/autocomplete-shared": "1.19.8"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.19.9",
+        "@algolia/autocomplete-shared": "1.19.9"
+      }
+    },
+    "node_modules/@algolia/autocomplete-js": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-js/-/autocomplete-js-1.19.9.tgz",
+      "integrity": "sha512-AXtqH+BBjDrTeoqCqOom082umhMtL/RF3+DVQSkoukh/1aaFdevNAtCqxwQSUCKQFLo0YLcDsB0cBItnl1X+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.19.9",
+        "@algolia/autocomplete-preset-algolia": "1.19.9",
+        "@algolia/autocomplete-shared": "1.19.9",
+        "htm": "^3.1.1",
+        "preact": "^10.13.2"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.5.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-js/node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.19.9.tgz",
+      "integrity": "sha512-x/vKrHNy2Swp83AJ+PX0hhxhkgUqWVNV6bk440LkqQOwT8CfK4EN3M/gHIt8L9YAwbJvOgviE/Vr3g3AOyDwsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.19.9"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
       }
     },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.8.tgz",
-      "integrity": "sha512-ZvJWO8ZZJDpc1LNM2TTBdmQsZBLMR4rU5iNR2OYvEeFBiaf/0ESnRSSLQbryarJY4SVxtoz6A2ZtDMNM+iQEAA==",
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.9.tgz",
+      "integrity": "sha512-6mExC6X7762s2SV3eJy3QOkB8bdMmnUhQ2agvGVDuzwoGyr3PquGSY/0vPQXCfiAiCaXUz1rXn+lwghgSi0l0w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.19.8"
+        "@algolia/autocomplete-shared": "1.19.9"
       },
       "peerDependencies": {
         "search-insights": ">= 1 < 3"
       }
     },
-    "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.19.8",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.8.tgz",
-      "integrity": "sha512-h5hf2t8ejF6vlOgvLaZzQbWs5SyH2z4PAWygNAvvD/2RI29hdQ54ldUGwqVuj9Srs+n8XUKTPUqb7fvhBhQrnQ==",
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.9.tgz",
+      "integrity": "sha512-Na1OuceSJeg8j7ZWn5ssMu/Ax3amtOwk76u4h5J4eK2Nx2KB5qt0Z4cOapCsxot9VcEN11ADV5aUSlQF4RhGjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.9"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia/node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.9.tgz",
+      "integrity": "sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ==",
       "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
         "algoliasearch": ">= 4.9.1 < 6"
       }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.9.tgz",
+      "integrity": "sha512-YosP9Uoek6y/Ur1r1qeogk4biMe/hzkyNcgMCciw0//3XpCM7VlYLSHnyt/vOnEOGhCCc0+3v+unEiH6zz+Z1A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-theme-classic": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-theme-classic/-/autocomplete-theme-classic-1.19.9.tgz",
+      "integrity": "sha512-MWCQXWC1qbDDXE1W0fPPGRLNNRLy8zupd6pRCabBuI6gyjR0aJaah5m3S1MucJcmXRqV9/ErkMBjnw7iKGCrvA==",
+      "license": "MIT"
     },
     "node_modules/@algolia/client-abtesting": {
       "version": "5.52.1",
@@ -3371,43 +3431,22 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@docsearch/core": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.3.tgz",
-      "integrity": "sha512-rUOujwIpxJRgD7+kicVsI3D5sqBvdiRTquzWBpTEXZs8ZXfGbfzpus5HqumaNYTppN2HvH8E2yNuRwYdHJeOlA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": ">= 16.8.0 < 20.0.0",
-        "react": ">= 16.8.0 < 20.0.0",
-        "react-dom": ">= 16.8.0 < 20.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@docsearch/css": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.3.tgz",
-      "integrity": "sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.9.0.tgz",
+      "integrity": "sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==",
       "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.3.tgz",
-      "integrity": "sha512-Bg2wdDsoQVlNCcEKuEJAU04tvHCqgx8rIu+uIoM4pRtcx3TBKJuXutJik3LTA8LRc9YEyHkrYUrmcC0D7BYf+g==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.9.0.tgz",
+      "integrity": "sha512-mb5FOZYZIkRQ6s/NWnM98k879vu5pscWqTLubLFBO87igYYT4VzVazh4h5o/zCvTIZgEt3PvsCOMOswOUo9yHQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-core": "1.19.2",
-        "@docsearch/core": "4.6.3",
-        "@docsearch/css": "4.6.3"
+        "@algolia/autocomplete-core": "1.17.9",
+        "@algolia/autocomplete-preset-algolia": "1.17.9",
+        "@docsearch/css": "3.9.0",
+        "algoliasearch": "^5.14.2"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3431,31 +3470,31 @@
       }
     },
     "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-core": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
-      "integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.9.tgz",
+      "integrity": "sha512-O7BxrpLDPJWWHv/DLA9DRFWs+iY1uOJZkqUwjS5HSZAGcl0hIVCQ97LTLewiZmZ402JYUrun+8NqFP+hCknlbQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
-        "@algolia/autocomplete-shared": "1.19.2"
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.9",
+        "@algolia/autocomplete-shared": "1.17.9"
       }
     },
     "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
-      "integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.9.tgz",
+      "integrity": "sha512-u1fEHkCbWF92DBeB/KHeMacsjsoI0wFhjZtlCq2ddZbAehshbZST6Hs0Avkc0s+4UyBGbMDnSuXHLuvRWK5iDQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.19.2"
+        "@algolia/autocomplete-shared": "1.17.9"
       },
       "peerDependencies": {
         "search-insights": ">= 1 < 3"
       }
     },
     "node_modules/@docsearch/react/node_modules/@algolia/autocomplete-shared": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
-      "integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
+      "version": "1.17.9",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.9.tgz",
+      "integrity": "sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ==",
       "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
@@ -4241,6 +4280,26 @@
         "@antfu/install-pkg": "^1.1.0",
         "@iconify/types": "^2.0.0",
         "mlly": "^1.8.0"
+      }
+    },
+    "node_modules/@igniteui/reveal-ai-plugin": {
+      "version": "1.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@igniteui/reveal-ai-plugin/1.0.0/174e61fd90d21a94c70bc283c20dca999f88f5c0",
+      "integrity": "sha512-u8IAKKh8eiMGrK4CJx5YP1liLdoAbytu3S/5jFJqLbQuzz70PbnzeyLi4lgWtKGE+kX7ujdd/knXJTDQEBWtXw==",
+      "dependencies": {
+        "@algolia/autocomplete-js": "^1.19.2",
+        "@algolia/autocomplete-theme-classic": "^1.19.2",
+        "algoliasearch": "^5.35.0",
+        "dompurify": "^3.2.6",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1"
+      },
+      "peerDependencies": {
+        "@docsearch/react": "^3.0.0",
+        "@docusaurus/core": "^3.4.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "webpack": "^5.0.0"
       }
     },
     "node_modules/@jest/schemas": {
@@ -10743,6 +10802,12 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -10787,6 +10852,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/html-void-elements": {
@@ -16642,6 +16717,24 @@
         "postcss": "^8.4.31"
       }
     },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/pretty-error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
@@ -17047,6 +17140,33 @@
       "peerDependencies": {
         "react-loadable": "*",
         "webpack": ">=4.41.1 || 5.x"
+      }
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
       }
     },
     "node_modules/react-router": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@docusaurus/preset-classic": "^3.10.1",
     "@docusaurus/remark-plugin-npm2yarn": "^3.10.1",
     "@docusaurus/theme-mermaid": "^3.10.1",
+    "@igniteui/reveal-ai-plugin": "^1.0.0",
     "@mdx-js/react": "^3.0.0",
     "@monaco-editor/react": "^4.4.6",
     "clsx": "^2.1.0",


### PR DESCRIPTION
## Overview

This PR introduces using the `Reveal AI` plugin instead of the plugin previously provided by `Inkeep` in the `Reveal Documentation`.

The plugin aligns with the appearance and behavior of the current Inkeep based plugin working in the `Reveal Documentation`.

It uses the `Reveal RAG knowledge` base set up in `Amazon Bedrock`.
The knowledge base contains data from the docs, blogs, as well as code repositories under the `RevealBi`, `RevealBi-MySql`, `RevealBi-Postgres`, `RevealBi-DomPlayground`, `RevealBI-JavaBuilder`, `RevealBi-CustomViz`, `RevealBi-BigQuery`, and `RevealBi-Rest-Json` `GitHub` organizations.
The plugin extracts data from the knowledge base related to the user's question and generates an answer using the `Claude Sonnet 4.6` model.

The plugin is available for testing as it has been published as a private package on GitHub Packages under `@igniteui/reveal-ai-plugin (v1.0.0)`.
You can find the release notes here: https://github.com/IgniteUI/reveal-ai-plugin/releases/tag/v1.0.0
If required, the plugin can be published under a different organization/owner.

In order to test it locally, you need to follow these steps:
- create a GitHub Personal Access Token (PAT)
you'll need a PAT with the read:packages scope. You can create one at github.com/settings/tokens.
- configure the npm registry
add a .npmrc file to the root of the Docusaurus project (or to your home directory ~/.npmrc) with the following content (replacing <YOUR_GITHUB_PAT> with the token from the first step):
@igniteui:registry=https://npm.pkg.github.com
//npm.pkg.github.com/:_authToken=<YOUR_GITHUB_PAT>
- register the plugin (done in this PR)
in docusaurus.config.ts, replace the Inkeep entry in the plugins array with the following:
['@igniteui/reveal-ai-plugin', { stage: 'dev' }]

Passing  { stage: 'dev' } lets you test the plugin locally without running into CORS errors.
**Important** - [the stage parameter](https://github.com/IgniteUI/reveal-ai-plugin/blob/master/README.md#plugin-options) is only required for local testing, when the PR gets merged, the parameter should be dropped in order for the deployed `Documentation` to make requests to the production stage.

## Additional details:

- structure and contents of the Reveal RAG knowledge base in AWS (general overview of the RAG related resources is available [here](https://infragistics.visualstudio.com/Indigo_Platform/_wiki/wikis/Indigo_AppBuilder.wiki/2339/AWS-Resources-Architecture-and-Setup-for-the-Infragistics-AI-Customer-Support))
- the ai-agent-gateway service, which exposes an endpoint for invoking the RAG ([source code](https://github.com/IgniteUI/ai-agent-gateway/blob/master/README.md), and [Swagger UI](https://ai-agent-gateway.infragistics.com/swagger/index.html) page)
- the reveal-ai-plugin which can replace the Inkeep plugin in the Reveal docusaurus project (source code for the plugin is [here](https://github.com/IgniteUI/reveal-ai-plugin/blob/master/README.md),