### PR TITLE
Updates AI Chat Docs Dashboard Loading Example

### DIFF
--- a/docs/ai/sdk-chat.md
+++ b/docs/ai/sdk-chat.md
@@ -11,6 +11,7 @@ The `client.ai.chat.sendMessage()` method enables conversational analytics — u
 
 ```typescript
 import { RevealSdkClient } from '@revealbi/api';
+import { RevealUtility } from 'reveal-sdk';
 
 const client = RevealSdkClient.getInstance();
 
@@ -28,7 +29,9 @@ console.log(response.usage?.inputTokens, response.usage?.outputTokens);
 
 if (response.dashboard) {
   // Load the generated dashboard
-  loadDashboard(response.dashboard);
+  const json = JSON.parse(response.dashboard);
+  const dashboard = RevealUtility.createDashboardFromJsonObject(json);
+  revealView.dashboard = dashboard;
 }
 ```
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ai/sdk-chat.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ai/sdk-chat.md
@@ -25,7 +25,9 @@ console.log(response.explanation);
 
 if (response.dashboard) {
   // Load the generated dashboard
-  loadDashboard(response.dashboard);
+  const json = JSON.parse(response.dashboard);
+  const dashboard = RevealUtility.createDashboardFromJsonObject(json);
+  revealView.dashboard = dashboard;
 }
 ```
 

--- a/i18n/ja/docusaurus-plugin-content-docs/current/ai/sdk-chat.md
+++ b/i18n/ja/docusaurus-plugin-content-docs/current/ai/sdk-chat.md
@@ -11,6 +11,7 @@ sidebar_label: チャット
 
 ```typescript
 import { RevealSdkClient } from '@revealbi/api';
+import { RevealUtility } from 'reveal-sdk';
 
 const client = RevealSdkClient.getInstance();
 


### PR DESCRIPTION
Updates the AI chat documentation to provide a clearer and correct example of how to load a generated dashboard when it is returned as a JSON string.

- Demonstrates parsing the JSON string from the response.
- Uses `RevealUtility.createDashboardFromJsonObject` to instantiate the dashboard.
- Assigns the created dashboard to the `revealView` instance.
- Applies this change to both English and Japanese documentation.