### PR TITLE
Bump the reveal-ai-plugin to v1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@docusaurus/preset-classic": "^3.10.1",
         "@docusaurus/remark-plugin-npm2yarn": "^3.10.1",
         "@docusaurus/theme-mermaid": "^3.10.1",
-        "@igniteui/reveal-ai-plugin": "^1.2.0",
+        "@igniteui/reveal-ai-plugin": "^1.2.1",
         "@mdx-js/react": "^3.0.0",
         "@monaco-editor/react": "^4.4.6",
         "clsx": "^2.1.0",
@@ -4283,9 +4283,9 @@
       }
     },
     "node_modules/@igniteui/reveal-ai-plugin": {
-      "version": "1.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@igniteui/reveal-ai-plugin/1.2.0/53bebf3f222cd1d2f3233bf8d9d580429c487226",
-      "integrity": "sha512-Z3hcE7i2oa5CvZND1PmeSHrt64UaFMqTNTgmMQmsn5C1f67JoHcrIBpI5xaR6dz7QPmeZJAt5KNKwbqZCPz+TA==",
+      "version": "1.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@igniteui/reveal-ai-plugin/1.2.1/c9bccf76116187ebfb6777f14449602d9d2ec9d6",
+      "integrity": "sha512-qhRHX6rbNNHUJuf2SfOEqn8KH587XXED0nEHc1f+NU7bDzqwLXN0A5j0vJWO5ChKHj43kq7646Ac8BjH4LHQqA==",
       "dependencies": {
         "@algolia/autocomplete-js": "^1.19.9",
         "@algolia/autocomplete-theme-classic": "^1.19.9",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@docusaurus/preset-classic": "^3.10.1",
     "@docusaurus/remark-plugin-npm2yarn": "^3.10.1",
     "@docusaurus/theme-mermaid": "^3.10.1",
-    "@igniteui/reveal-ai-plugin": "^1.2.0",
+    "@igniteui/reveal-ai-plugin": "^1.2.1",
     "@mdx-js/react": "^3.0.0",
     "@monaco-editor/react": "^4.4.6",
     "clsx": "^2.1.0",


### PR DESCRIPTION
### Overview

The PR updates the `reveal-ai-plugin` to v1.2.1 which contains various UI/UX improvements related to prompt length limits, citation handling, and chat auto-scroll behavior.

The release notes for the plugin can be checked [here](https://github.com/IgniteUI/reveal-ai-plugin/releases/tag/v1.2.1).